### PR TITLE
[feat] 장소 검색 API 구현 (카카오 카테고리 검색 API 연동)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,6 +66,12 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+	// WebClient
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
+	// JSON 파싱
+	implementation 'com.fasterxml.jackson.core:jackson-databind'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -69,9 +69,6 @@ dependencies {
 
 	// WebClient
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
-
-	// JSON 파싱
-	implementation 'com.fasterxml.jackson.core:jackson-databind'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/bready/server/auth/exception/AuthErrorCase.java
+++ b/src/main/java/com/bready/server/auth/exception/AuthErrorCase.java
@@ -1,0 +1,34 @@
+package com.bready.server.auth.exception;
+
+import com.bready.server.global.exception.ErrorCase;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum AuthErrorCase implements ErrorCase {
+
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, 1001, "유효하지 않은 토큰입니다."),
+    EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, 1002, "토큰이 만료되었습니다."),
+    UNAUTHORIZED(HttpStatus.FORBIDDEN, 1003, "접근 권한이 없습니다.");
+
+    private final HttpStatus httpStatus;
+    private final Integer errorCode;
+    private final String message;
+
+    @Override
+    public Integer getHttpStatusCode() {
+        return httpStatus.value();
+    }
+
+    @Override
+    public Integer getErrorCode() {
+        return errorCode;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/com/bready/server/global/config/WebClientConfig.java
+++ b/src/main/java/com/bready/server/global/config/WebClientConfig.java
@@ -1,0 +1,31 @@
+package com.bready.server.global.config;
+
+import io.netty.channel.ChannelOption;
+import io.netty.handler.timeout.ReadTimeoutHandler;
+import io.netty.handler.timeout.WriteTimeoutHandler;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.netty.http.client.HttpClient;
+
+import java.time.Duration;
+
+@Configuration
+public class WebClientConfig {
+
+    @Bean
+    public WebClient webClient() {
+        HttpClient httpClient = HttpClient.create()
+                .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 5000)
+                .responseTimeout(Duration.ofSeconds(5))
+                .doOnConnected(conn ->
+                        conn.addHandlerLast(new ReadTimeoutHandler(5))
+                                .addHandlerLast(new WriteTimeoutHandler(5))
+                );
+
+        return WebClient.builder()
+                .clientConnector(new ReactorClientHttpConnector(httpClient))
+                .build();
+    }
+}

--- a/src/main/java/com/bready/server/global/config/WebClientConfig.java
+++ b/src/main/java/com/bready/server/global/config/WebClientConfig.java
@@ -14,10 +14,10 @@ import java.time.Duration;
 @Configuration
 public class WebClientConfig {
 
-    @Bean
-    public WebClient webClient() {
+    @Bean(name = "kakaoWebClient")
+    public WebClient kakaoWebClient() {
         HttpClient httpClient = HttpClient.create()
-                .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 5000)
+                .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 5_000)
                 .responseTimeout(Duration.ofSeconds(5))
                 .doOnConnected(conn ->
                         conn.addHandlerLast(new ReadTimeoutHandler(5))
@@ -26,6 +26,9 @@ public class WebClientConfig {
 
         return WebClient.builder()
                 .clientConnector(new ReactorClientHttpConnector(httpClient))
+                .codecs(configurer ->
+                        configurer.defaultCodecs().maxInMemorySize(1024 * 1024)
+                )
                 .build();
     }
 }

--- a/src/main/java/com/bready/server/place/controller/PlaceSearchController.java
+++ b/src/main/java/com/bready/server/place/controller/PlaceSearchController.java
@@ -1,0 +1,99 @@
+package com.bready.server.place.controller;
+
+import com.bready.server.global.exception.ApplicationException;
+import com.bready.server.global.response.CommonResponse;
+import com.bready.server.place.domain.PlaceCategoryType;
+import com.bready.server.place.dto.PlaceSearchResponse;
+import com.bready.server.place.exception.PlaceErrorCase;
+import com.bready.server.place.service.PlaceSearchService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import lombok.RequiredArgsConstructor;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/places")
+@RequiredArgsConstructor
+@Validated
+public class PlaceSearchController {
+
+    private final PlaceSearchService placeSearchService;
+
+    @GetMapping("/search")
+    @Operation(
+            summary = "장소 검색",
+            description =
+                    """
+                    카카오 장소 검색 API를 사용하여 사용자가 선택한 BReady 카테고리 기준으로 주변 장소 목록을 조회합니다.
+                    """
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "검색 성공",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 (카테고리 누락, 반경 범위 초과 등)",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "404", description = "검색 결과 없음",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class)))
+    })
+    public CommonResponse<List<PlaceSearchResponse>> searchPlaces(
+            @Parameter(
+                    name = "category",
+                    description = "BReady 장소 카테고리",
+                    required = true,
+                    in = ParameterIn.QUERY,
+                    example = "CAFE"
+            )
+            @RequestParam PlaceCategoryType category,
+
+            @Parameter(
+                    name = "latitude",
+                    description = "사용자 위도",
+                    in = ParameterIn.QUERY,
+                    example = "37.544"
+            )
+            @RequestParam(required = false) Double latitude,
+
+            @Parameter(
+                    name = "longitude",
+                    description = "사용자 경도",
+                    in = ParameterIn.QUERY,
+                    example = "127.055"
+            )
+            @RequestParam(required = false) Double longitude,
+
+            @Parameter(
+                    name = "radius",
+                    description = "검색 반경 (미터 단위, 최대 10,000m)",
+                    in = ParameterIn.QUERY,
+                    example = "2000"
+            )
+            @RequestParam(defaultValue = "2000")
+            @Min(0) @Max(10000) Integer radius
+    ) {
+        // 좌표는 위도,경도 둘다 필요
+        if ((latitude == null && longitude != null) ||
+                (latitude != null && longitude == null)) {
+            throw ApplicationException.from(PlaceErrorCase.LOCATION_REQUIRED);
+        }
+
+        List<PlaceSearchResponse> results =
+                placeSearchService.search(category, latitude, longitude, radius);
+
+        // 결과 없으면 에러 처리
+        if (results.isEmpty()) {
+            throw ApplicationException.from(PlaceErrorCase.PLACE_NOT_FOUND);
+        }
+
+        return CommonResponse.success(results);
+    }
+}

--- a/src/main/java/com/bready/server/place/controller/PlaceSearchController.java
+++ b/src/main/java/com/bready/server/place/controller/PlaceSearchController.java
@@ -13,11 +13,16 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
@@ -61,7 +66,10 @@ public class PlaceSearchController {
                     in = ParameterIn.QUERY,
                     example = "37.544"
             )
-            @RequestParam(required = false) Double latitude,
+            @RequestParam(required = false)
+            @DecimalMin("-90.0")
+            @DecimalMax("90.0")
+            Double latitude,
 
             @Parameter(
                     name = "longitude",
@@ -69,7 +77,10 @@ public class PlaceSearchController {
                     in = ParameterIn.QUERY,
                     example = "127.055"
             )
-            @RequestParam(required = false) Double longitude,
+            @RequestParam(required = false)
+            @DecimalMin("-180.0")
+            @DecimalMax("180.0")
+            Double longitude,
 
             @Parameter(
                     name = "radius",

--- a/src/main/java/com/bready/server/place/domain/PlaceCategoryType.java
+++ b/src/main/java/com/bready/server/place/domain/PlaceCategoryType.java
@@ -1,0 +1,31 @@
+package com.bready.server.place.domain;
+
+import lombok.Getter;
+
+@Getter
+public enum PlaceCategoryType {
+
+    MEAL("식사", "음식점", "FD6", true),
+    CAFE("카페", "카페", "CE7", true),
+    EXHIBITION("전시", "전시관", null, true),
+    WALK("산책", "공원", "AT4", false),
+    SHOPPING("쇼핑", "쇼핑", null, true),
+    REST("휴식", "휴식", null, true);
+
+    private final String label;
+    private final String keyword;
+    private final String kakaoCategoryCode;
+    private final boolean indoor;
+
+    PlaceCategoryType(
+            String label,
+            String keyword,
+            String kakaoCategoryCode,
+            boolean indoor
+    ) {
+        this.label = label;
+        this.keyword = keyword;
+        this.kakaoCategoryCode = kakaoCategoryCode;
+        this.indoor = indoor;
+    }
+}

--- a/src/main/java/com/bready/server/place/dto/PlaceSearchResponse.java
+++ b/src/main/java/com/bready/server/place/dto/PlaceSearchResponse.java
@@ -1,0 +1,15 @@
+package com.bready.server.place.dto;
+
+import lombok.Builder;
+
+import java.math.BigDecimal;
+
+@Builder
+public record PlaceSearchResponse(
+        String externalId,
+        String name,
+        String address,
+        BigDecimal latitude,
+        BigDecimal longitude,
+        Boolean isIndoor
+) {}

--- a/src/main/java/com/bready/server/place/dto/kakao/KakaoPlaceDocument.java
+++ b/src/main/java/com/bready/server/place/dto/kakao/KakaoPlaceDocument.java
@@ -1,0 +1,28 @@
+package com.bready.server.place.dto.kakao;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+@Getter
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class KakaoPlaceDocument {
+
+    @JsonProperty("id")
+    private String id;
+
+    @JsonProperty("place_name")
+    private String placeName;
+
+    @JsonProperty("address_name")
+    private String addressName;
+
+    @JsonProperty("road_address_name")
+    private String roadAddressName;
+
+    @JsonProperty("x")
+    private String longitude;
+
+    @JsonProperty("y")
+    private String latitude;
+}

--- a/src/main/java/com/bready/server/place/exception/PlaceErrorCase.java
+++ b/src/main/java/com/bready/server/place/exception/PlaceErrorCase.java
@@ -10,8 +10,11 @@ import org.springframework.http.HttpStatus;
 public enum PlaceErrorCase implements ErrorCase {
 
     PLACE_SEARCH_FAILED(HttpStatus.BAD_REQUEST, 4001, "장소 검색에 실패했습니다."),
-    INVALID_PLACE_TYPE(HttpStatus.BAD_REQUEST, 3002, "장소 타입이 유효하지 않습니다."),
-    PLACE_ACCESS_DENIED(HttpStatus.FORBIDDEN, 3003, "해당 장소에 대한 접근 권한이 없습니다.");
+    INVALID_PLACE_TYPE(HttpStatus.BAD_REQUEST, 4002, "장소 타입이 유효하지 않습니다."),
+    PLACE_ACCESS_DENIED(HttpStatus.FORBIDDEN, 4003, "해당 장소에 대한 접근 권한이 없습니다."),
+    INVALID_SEARCH_KEYWORD(HttpStatus.BAD_REQUEST, 4100, "검색 키워드가 비어있습니다."),
+    KAKAO_CLIENT_ERROR(HttpStatus.BAD_GATEWAY, 4101, "카카오 장소 검색 요청이 잘못되었습니다."),
+    KAKAO_SERVER_ERROR(HttpStatus.BAD_GATEWAY, 4102, "카카오 장소 서비스에 장애가 발생했습니다.");
 
     private final HttpStatus httpStatus;
     private final Integer errorCode;

--- a/src/main/java/com/bready/server/place/exception/PlaceErrorCase.java
+++ b/src/main/java/com/bready/server/place/exception/PlaceErrorCase.java
@@ -13,7 +13,8 @@ public enum PlaceErrorCase implements ErrorCase {
     LOCATION_REQUIRED(HttpStatus.BAD_REQUEST, 4103, "위도와 경도는 함께 전달되어야 합니다."),
     PLACE_NOT_FOUND(HttpStatus.NOT_FOUND, 4104, "조건에 맞는 장소를 찾을 수 없습니다."),
     KAKAO_CLIENT_ERROR(HttpStatus.BAD_GATEWAY, 4101, "카카오 장소 검색 요청이 잘못되었습니다."),
-    KAKAO_SERVER_ERROR(HttpStatus.BAD_GATEWAY, 4102, "카카오 장소 서비스에 장애가 발생했습니다.");
+    KAKAO_SERVER_ERROR(HttpStatus.BAD_GATEWAY, 4102, "카카오 장소 서비스에 장애가 발생했습니다."),
+    KAKAO_RESPONSE_PARSE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 4103, "카카오 장소 응답 파싱에 실패했습니다.");
 
     private final HttpStatus httpStatus;
     private final Integer errorCode;

--- a/src/main/java/com/bready/server/place/exception/PlaceErrorCase.java
+++ b/src/main/java/com/bready/server/place/exception/PlaceErrorCase.java
@@ -9,10 +9,9 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum PlaceErrorCase implements ErrorCase {
 
-    PLACE_SEARCH_FAILED(HttpStatus.BAD_REQUEST, 4001, "장소 검색에 실패했습니다."),
-    INVALID_PLACE_TYPE(HttpStatus.BAD_REQUEST, 4002, "장소 타입이 유효하지 않습니다."),
-    PLACE_ACCESS_DENIED(HttpStatus.FORBIDDEN, 4003, "해당 장소에 대한 접근 권한이 없습니다."),
     INVALID_SEARCH_KEYWORD(HttpStatus.BAD_REQUEST, 4100, "검색 키워드가 비어있습니다."),
+    LOCATION_REQUIRED(HttpStatus.BAD_REQUEST, 4103, "위도와 경도는 함께 전달되어야 합니다."),
+    PLACE_NOT_FOUND(HttpStatus.NOT_FOUND, 4104, "조건에 맞는 장소를 찾을 수 없습니다."),
     KAKAO_CLIENT_ERROR(HttpStatus.BAD_GATEWAY, 4101, "카카오 장소 검색 요청이 잘못되었습니다."),
     KAKAO_SERVER_ERROR(HttpStatus.BAD_GATEWAY, 4102, "카카오 장소 서비스에 장애가 발생했습니다.");
 

--- a/src/main/java/com/bready/server/place/exception/PlaceErrorCase.java
+++ b/src/main/java/com/bready/server/place/exception/PlaceErrorCase.java
@@ -10,11 +10,11 @@ import org.springframework.http.HttpStatus;
 public enum PlaceErrorCase implements ErrorCase {
 
     INVALID_SEARCH_KEYWORD(HttpStatus.BAD_REQUEST, 4100, "검색 키워드가 비어있습니다."),
-    LOCATION_REQUIRED(HttpStatus.BAD_REQUEST, 4103, "위도와 경도는 함께 전달되어야 합니다."),
-    PLACE_NOT_FOUND(HttpStatus.NOT_FOUND, 4104, "조건에 맞는 장소를 찾을 수 없습니다."),
-    KAKAO_CLIENT_ERROR(HttpStatus.BAD_GATEWAY, 4101, "카카오 장소 검색 요청이 잘못되었습니다."),
-    KAKAO_SERVER_ERROR(HttpStatus.BAD_GATEWAY, 4102, "카카오 장소 서비스에 장애가 발생했습니다."),
-    KAKAO_RESPONSE_PARSE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 4103, "카카오 장소 응답 파싱에 실패했습니다.");
+    LOCATION_REQUIRED(HttpStatus.BAD_REQUEST, 4101, "위도와 경도는 함께 전달되어야 합니다."),
+    PLACE_NOT_FOUND(HttpStatus.NOT_FOUND, 4102, "조건에 맞는 장소를 찾을 수 없습니다."),
+    KAKAO_CLIENT_ERROR(HttpStatus.BAD_GATEWAY, 4103, "카카오 장소 검색 요청이 잘못되었습니다."),
+    KAKAO_SERVER_ERROR(HttpStatus.BAD_GATEWAY, 4104, "카카오 장소 서비스에 장애가 발생했습니다."),
+    KAKAO_RESPONSE_PARSE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 4105, "카카오 장소 응답 파싱에 실패했습니다.");
 
     private final HttpStatus httpStatus;
     private final Integer errorCode;

--- a/src/main/java/com/bready/server/place/exception/PlaceErrorCase.java
+++ b/src/main/java/com/bready/server/place/exception/PlaceErrorCase.java
@@ -1,0 +1,34 @@
+package com.bready.server.place.exception;
+
+import com.bready.server.global.exception.ErrorCase;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum PlaceErrorCase implements ErrorCase {
+
+    PLACE_NOT_FOUND(HttpStatus.NOT_FOUND, 3001, "장소를 찾을 수 없습니다."),
+    INVALID_PLACE_TYPE(HttpStatus.BAD_REQUEST, 3002, "장소 타입이 유효하지 않습니다."),
+    PLACE_ACCESS_DENIED(HttpStatus.FORBIDDEN, 3003, "해당 장소에 대한 접근 권한이 없습니다.");
+
+    private final HttpStatus httpStatus;
+    private final Integer errorCode;
+    private final String message;
+
+    @Override
+    public Integer getHttpStatusCode() {
+        return httpStatus.value();
+    }
+
+    @Override
+    public Integer getErrorCode() {
+        return errorCode;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/com/bready/server/place/exception/PlaceErrorCase.java
+++ b/src/main/java/com/bready/server/place/exception/PlaceErrorCase.java
@@ -9,7 +9,7 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum PlaceErrorCase implements ErrorCase {
 
-    PLACE_NOT_FOUND(HttpStatus.NOT_FOUND, 3001, "장소를 찾을 수 없습니다."),
+    PLACE_SEARCH_FAILED(HttpStatus.BAD_REQUEST, 4001, "장소 검색에 실패했습니다."),
     INVALID_PLACE_TYPE(HttpStatus.BAD_REQUEST, 3002, "장소 타입이 유효하지 않습니다."),
     PLACE_ACCESS_DENIED(HttpStatus.FORBIDDEN, 3003, "해당 장소에 대한 접근 권한이 없습니다.");
 

--- a/src/main/java/com/bready/server/place/external/KakaoPlaceClient.java
+++ b/src/main/java/com/bready/server/place/external/KakaoPlaceClient.java
@@ -86,6 +86,6 @@ public class KakaoPlaceClient {
                                 ))
                 )
                 .bodyToMono(String.class)
-                .block();
+                .block(java.time.Duration.ofSeconds(10));
     }
 }

--- a/src/main/java/com/bready/server/place/external/KakaoPlaceClient.java
+++ b/src/main/java/com/bready/server/place/external/KakaoPlaceClient.java
@@ -1,0 +1,68 @@
+package com.bready.server.place.external;
+
+import com.bready.server.global.exception.ApplicationException;
+import com.bready.server.place.exception.PlaceErrorCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+@Component
+@RequiredArgsConstructor
+public class KakaoPlaceClient {
+
+    private final WebClient webClient;
+
+    @Value("${kakao.rest-api-key}")
+    private String restApiKey;
+
+    public String search(
+            String keyword,
+            Double latitude,
+            Double longitude,
+            Integer radius,
+            String categoryGroupCode
+    ) {
+        if (keyword == null || keyword.isBlank()) {
+            throw ApplicationException.from(PlaceErrorCase.INVALID_SEARCH_KEYWORD);
+        }
+
+        return webClient.get()
+                .uri(uriBuilder -> {
+                    uriBuilder
+                            .scheme("https")
+                            .host("dapi.kakao.com")
+                            .path("/v2/local/search/keyword.json")
+                            .queryParam("query", keyword)
+                            .queryParam("size", 15);
+
+                    if (latitude != null && longitude != null) {
+                        uriBuilder.queryParam("y", latitude).queryParam("x", longitude);
+                    }
+
+                    if (radius != null) {
+                        uriBuilder.queryParam("radius", radius);
+                    }
+
+                    if (categoryGroupCode != null) {
+                        uriBuilder.queryParam("category_group_code", categoryGroupCode);
+                    }
+
+                    return uriBuilder.build();
+                })
+                .header(HttpHeaders.AUTHORIZATION, "KakaoAK " + restApiKey)
+                .retrieve()
+                .onStatus(
+                        status -> status.is4xxClientError(),
+                        response -> Mono.error(ApplicationException.from(PlaceErrorCase.KAKAO_CLIENT_ERROR))
+                )
+                .onStatus(
+                        status -> status.is5xxServerError(),
+                        response -> Mono.error(ApplicationException.from(PlaceErrorCase.KAKAO_SERVER_ERROR))
+                )
+                .bodyToMono(String.class)
+                .block();
+    }
+}

--- a/src/main/java/com/bready/server/place/external/KakaoPlaceClient.java
+++ b/src/main/java/com/bready/server/place/external/KakaoPlaceClient.java
@@ -2,21 +2,31 @@ package com.bready.server.place.external;
 
 import com.bready.server.global.exception.ApplicationException;
 import com.bready.server.place.exception.PlaceErrorCase;
-import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
 
 @Component
-@RequiredArgsConstructor
 public class KakaoPlaceClient {
 
-    private final WebClient webClient;
+    private static final Logger log = LoggerFactory.getLogger(KakaoPlaceClient.class);
 
-    @Value("${kakao.rest-api-key}")
-    private String restApiKey;
+    private final WebClient webClient;
+    private final String restApiKey;
+
+    public KakaoPlaceClient(
+            @Qualifier("kakaoWebClient") WebClient webClient,
+            @Value("${kakao.rest-api-key}") String restApiKey
+    ) {
+        this.webClient = webClient;
+        this.restApiKey = restApiKey;
+    }
 
     public String search(
             String keyword,
@@ -39,7 +49,8 @@ public class KakaoPlaceClient {
                             .queryParam("size", 15);
 
                     if (latitude != null && longitude != null) {
-                        uriBuilder.queryParam("y", latitude).queryParam("x", longitude);
+                        uriBuilder.queryParam("y", latitude)
+                                .queryParam("x", longitude);
                     }
 
                     if (radius != null) {
@@ -55,12 +66,24 @@ public class KakaoPlaceClient {
                 .header(HttpHeaders.AUTHORIZATION, "KakaoAK " + restApiKey)
                 .retrieve()
                 .onStatus(
-                        status -> status.is4xxClientError(),
-                        response -> Mono.error(ApplicationException.from(PlaceErrorCase.KAKAO_CLIENT_ERROR))
+                        HttpStatusCode::is4xxClientError,
+                        response -> response.bodyToMono(String.class)
+                                .doOnNext(body ->
+                                        log.warn("Kakao API 4xx error response: {}", body)
+                                )
+                                .then(Mono.error(
+                                        ApplicationException.from(PlaceErrorCase.KAKAO_CLIENT_ERROR)
+                                ))
                 )
                 .onStatus(
-                        status -> status.is5xxServerError(),
-                        response -> Mono.error(ApplicationException.from(PlaceErrorCase.KAKAO_SERVER_ERROR))
+                        HttpStatusCode::is5xxServerError,
+                        response -> response.bodyToMono(String.class)
+                                .doOnNext(body ->
+                                        log.error("Kakao API 5xx error response: {}", body)
+                                )
+                                .then(Mono.error(
+                                        ApplicationException.from(PlaceErrorCase.KAKAO_SERVER_ERROR)
+                                ))
                 )
                 .bodyToMono(String.class)
                 .block();

--- a/src/main/java/com/bready/server/place/service/PlaceSearchService.java
+++ b/src/main/java/com/bready/server/place/service/PlaceSearchService.java
@@ -1,0 +1,75 @@
+package com.bready.server.place.service;
+
+import com.bready.server.place.domain.PlaceCategoryType;
+import com.bready.server.place.dto.PlaceSearchResponse;
+import com.bready.server.place.dto.kakao.KakaoPlaceDocument;
+import com.bready.server.place.external.KakaoPlaceClient;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class PlaceSearchService {
+
+    private final KakaoPlaceClient kakaoPlaceClient;
+    private final ObjectMapper objectMapper;
+
+    public List<PlaceSearchResponse> search(
+            PlaceCategoryType category,
+            Double latitude,
+            Double longitude,
+            Integer radius
+    ) {
+        String response = kakaoPlaceClient.search(
+                category.getKeyword(),
+                latitude,
+                longitude,
+                radius,
+                category.getKakaoCategoryCode()
+        );
+
+        try {
+            JsonNode documents = objectMapper
+                    .readTree(response)
+                    .path("documents");
+
+            List<KakaoPlaceDocument> kakaoPlaces =
+                    objectMapper.readerForListOf(KakaoPlaceDocument.class)
+                            .readValue(documents.toString());
+
+            return kakaoPlaces.stream()
+                    .map(p -> PlaceSearchResponse.builder()
+                            .externalId("kakao-" + p.getId())
+                            .name(p.getPlaceName())
+                            .address(
+                                    p.getRoadAddressName() != null && !p.getRoadAddressName().isBlank()
+                                            ? p.getRoadAddressName()
+                                            : p.getAddressName()
+                            )
+                            .latitude(toBigDecimal(p.getLatitude()))
+                            .longitude(toBigDecimal(p.getLongitude()))
+                            .isIndoor(category.isIndoor())
+                            .build()
+                    )
+                    .toList();
+
+        } catch (Exception e) {
+            throw new RuntimeException("카카오 장소 검색 파싱 실패", e);
+        }
+    }
+
+    private BigDecimal toBigDecimal(String value) {
+        try {
+            return value != null && !value.isBlank()
+                    ? new BigDecimal(value)
+                    : null;
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/bready/server/place/service/PlaceSearchService.java
+++ b/src/main/java/com/bready/server/place/service/PlaceSearchService.java
@@ -1,5 +1,6 @@
 package com.bready.server.place.service;
 
+import com.bready.server.global.exception.ApplicationException;
 import com.bready.server.place.domain.PlaceCategoryType;
 import com.bready.server.place.dto.PlaceSearchResponse;
 import com.bready.server.place.dto.kakao.KakaoPlaceDocument;
@@ -8,7 +9,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-
+import com.bready.server.place.exception.PlaceErrorCase;
 import java.math.BigDecimal;
 import java.util.List;
 
@@ -59,7 +60,7 @@ public class PlaceSearchService {
                     .toList();
 
         } catch (Exception e) {
-            throw new RuntimeException("카카오 장소 검색 파싱 실패", e);
+            throw ApplicationException.from(PlaceErrorCase.KAKAO_RESPONSE_PARSE_FAILED);
         }
     }
 

--- a/src/main/java/com/bready/server/place/service/PlaceSearchService.java
+++ b/src/main/java/com/bready/server/place/service/PlaceSearchService.java
@@ -60,7 +60,7 @@ public class PlaceSearchService {
                     .toList();
 
         } catch (Exception e) {
-            throw ApplicationException.from(PlaceErrorCase.KAKAO_RESPONSE_PARSE_FAILED);
+            throw new ApplicationException(PlaceErrorCase.KAKAO_RESPONSE_PARSE_FAILED, e);
         }
     }
 

--- a/src/main/java/com/bready/server/plan/exception/PlanErrorCase.java
+++ b/src/main/java/com/bready/server/plan/exception/PlanErrorCase.java
@@ -1,0 +1,34 @@
+package com.bready.server.plan.exception;
+
+import com.bready.server.global.exception.ErrorCase;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum PlanErrorCase implements ErrorCase {
+
+    PLAN_NOT_FOUND(HttpStatus.NOT_FOUND, 4001, "플랜을 찾을 수 없습니다."),
+    PLAN_ACCESS_DENIED(HttpStatus.FORBIDDEN, 4002, "플랜에 대한 접근 권한이 없습니다.");
+
+    private final HttpStatus httpStatus;
+    private final Integer errorCode;
+    private final String message;
+
+    @Override
+    public Integer getHttpStatusCode() {
+        return httpStatus.value();
+    }
+
+    @Override
+    public Integer getErrorCode() {
+        return errorCode;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}
+

--- a/src/main/java/com/bready/server/recommendation/exception/RecommendationErrorCase.java
+++ b/src/main/java/com/bready/server/recommendation/exception/RecommendationErrorCase.java
@@ -1,0 +1,33 @@
+package com.bready.server.recommendation.exception;
+
+import com.bready.server.global.exception.ErrorCase;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum RecommendationErrorCase implements ErrorCase {
+
+    RECOMMENDATION_NOT_FOUND(HttpStatus.NOT_FOUND, 5001, "추천 결과를 찾을 수 없습니다."),
+    RECOMMENDATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 5002, "추천 생성에 실패했습니다.");
+
+    private final HttpStatus httpStatus;
+    private final Integer errorCode;
+    private final String message;
+
+    @Override
+    public Integer getHttpStatusCode() {
+        return httpStatus.value();
+    }
+
+    @Override
+    public Integer getErrorCode() {
+        return errorCode;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/com/bready/server/stats/exception/StatsErrorCase.java
+++ b/src/main/java/com/bready/server/stats/exception/StatsErrorCase.java
@@ -1,0 +1,33 @@
+package com.bready.server.stats.exception;
+
+import com.bready.server.global.exception.ErrorCase;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum StatsErrorCase implements ErrorCase {
+
+    STATS_NOT_FOUND(HttpStatus.NOT_FOUND, 6001, "통계 데이터를 찾을 수 없습니다."),
+    STATS_CALCULATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 6002, "통계 계산에 실패했습니다.");
+
+    private final HttpStatus httpStatus;
+    private final Integer errorCode;
+    private final String message;
+
+    @Override
+    public Integer getHttpStatusCode() {
+        return httpStatus.value();
+    }
+
+    @Override
+    public Integer getErrorCode() {
+        return errorCode;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/com/bready/server/trigger/exception/TriggerErrorCase.java
+++ b/src/main/java/com/bready/server/trigger/exception/TriggerErrorCase.java
@@ -1,0 +1,32 @@
+package com.bready.server.trigger.exception;
+
+import com.bready.server.global.exception.ErrorCase;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum TriggerErrorCase implements ErrorCase {
+
+    TRIGGER_NOT_FOUND(HttpStatus.NOT_FOUND, 7001, "트리거를 찾을 수 없습니다."),
+    TRIGGER_ALREADY_EXECUTED(HttpStatus.BAD_REQUEST, 7002, "이미 실행된 트리거입니다.");
+    private final HttpStatus httpStatus;
+    private final Integer errorCode;
+    private final String message;
+
+    @Override
+    public Integer getHttpStatusCode() {
+        return httpStatus.value();
+    }
+
+    @Override
+    public Integer getErrorCode() {
+        return errorCode;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/com/bready/server/trigger/exception/TriggerErrorCase.java
+++ b/src/main/java/com/bready/server/trigger/exception/TriggerErrorCase.java
@@ -11,6 +11,7 @@ public enum TriggerErrorCase implements ErrorCase {
 
     TRIGGER_NOT_FOUND(HttpStatus.NOT_FOUND, 7001, "트리거를 찾을 수 없습니다."),
     TRIGGER_ALREADY_EXECUTED(HttpStatus.BAD_REQUEST, 7002, "이미 실행된 트리거입니다.");
+
     private final HttpStatus httpStatus;
     private final Integer errorCode;
     private final String message;

--- a/src/main/java/com/bready/server/user/exception/UserErrorCase.java
+++ b/src/main/java/com/bready/server/user/exception/UserErrorCase.java
@@ -1,0 +1,32 @@
+package com.bready.server.user.exception;
+
+import com.bready.server.global.exception.ErrorCase;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum UserErrorCase implements ErrorCase {
+
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, 2001, "사용자를 찾을 수 없습니다.");
+
+    private final HttpStatus httpStatus;
+    private final Integer errorCode;
+    private final String message;
+
+    @Override
+    public Integer getHttpStatusCode() {
+        return httpStatus.value();
+    }
+
+    @Override
+    public Integer getErrorCode() {
+        return errorCode;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -32,3 +32,6 @@ jwt:
   secret: ${JWT_SECRET:test-jwt-secret-minimum-32-bytes-required-for-validation}
   access-exp: 3600000
   refresh-exp: 1209600000
+
+kakao:
+  rest-api-key: test-kakao-api-key

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -34,4 +34,4 @@ jwt:
   refresh-exp: 1209600000
 
 kakao:
-  rest-api-key: test-kakao-api-key
+  rest-api-key: ${KAKAO_REST_API_KEY:test-kakao-api-key}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #15 

## 📝 작업 내용

- 카카오 로컬 API를 활용한 장소 검색 API 구현
- WebClient 기반 KakaoPlaceClient 외부 API 연동 로직 추가


## 🖼️ 스크린샷 (선택)
### 장소 검색 성공 (실제 카페들 반환 확인)
<img width="1512" height="945" alt="장소검색api호출성공" src="https://github.com/user-attachments/assets/f48c6585-75e6-47de-96d4-dc1434fcbf7c" />

### 장소 검색 성공 (실제 산책 관련 카테고리들 반환 확인)
<img width="1480" height="943" alt="장소검색성공2" src="https://github.com/user-attachments/assets/323593f9-7caa-436d-9f20-f88babefc00f" />

### 장소 검색 실패 (위도,경도 둘중 하나 입력하지 않았을때)
<img width="1499" height="942" alt="장소검색실패케이스" src="https://github.com/user-attachments/assets/bc6f88e7-592d-44d8-8141-3e4ca9fc8c03" />


## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특히 봐주었으면 하는 부분이 있다면 작성해주세요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 카테고리(식사/카페/전시/산책/쇼핑/휴식) 기반 장소 검색 API 추가 — 반경·위치 옵션으로 근처 장소의 이름·주소·좌표·실내 여부 제공
* **개선**
  * 외부 조회 신뢰성 향상: 요청/응답 타임아웃 및 메모리 제한 설정으로 안정성 강화
  * 외부 API 연동 처리 및 응답 파싱 안정성 개선
* **버그 수정 / 기타**
  * 인증·플랜·추천·통계·트리거·사용자 관련 사용자 친화적 오류 응답 추가
  * 테스트 설정에 외부 API 키 항목 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->