### PR TITLE
[test] 장소 검색 서비스/컨트롤러 단위 테스트 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ dependencies {
 
 	// Security
 	implementation 'org.springframework.boot:spring-boot-starter-security'
-	testImplementation 'org.springframework.boot:spring-boot-starter-security-test'
+	testImplementation 'org.springframework.security:spring-security-test'
 
 	// Validation
 	implementation 'org.springframework.boot:spring-boot-starter-validation'

--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,7 @@ dependencies {
 
 	// Security
 	implementation 'org.springframework.boot:spring-boot-starter-security'
+	testImplementation 'org.springframework.boot:spring-boot-starter-security-test'
 
 	// Validation
 	implementation 'org.springframework.boot:spring-boot-starter-validation'

--- a/src/test/java/com/bready/server/place/controller/PlaceSearchControllerTest.java
+++ b/src/test/java/com/bready/server/place/controller/PlaceSearchControllerTest.java
@@ -1,0 +1,94 @@
+package com.bready.server.place.controller;
+
+import com.bready.server.global.exception.GlobalExceptionHandler;
+import com.bready.server.place.domain.PlaceCategoryType;
+import com.bready.server.place.dto.PlaceSearchResponse;
+import com.bready.server.place.exception.PlaceErrorCase;
+import com.bready.server.place.service.PlaceSearchService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(PlaceSearchController.class)
+@Import(GlobalExceptionHandler.class)
+@AutoConfigureMockMvc(addFilters = false)
+class PlaceSearchControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private PlaceSearchService placeSearchService;
+
+    @Test
+    @DisplayName("정상 검색 요청 → 200 반환")
+    void search_success() throws Exception {
+        given(placeSearchService.search(
+                eq(PlaceCategoryType.CAFE),
+                eq(37.544),
+                eq(127.055),
+                eq(2000)
+        )).willReturn(List.of(
+                PlaceSearchResponse.builder()
+                        .externalId("kakao-1")
+                        .name("성수 카페")
+                        .address("서울 성동구")
+                        .latitude(BigDecimal.valueOf(37.544))
+                        .longitude(BigDecimal.valueOf(127.055))
+                        .isIndoor(true)
+                        .build()
+        ));
+
+        mockMvc.perform(get("/api/v1/places/search")
+                        .param("category", "CAFE")
+                        .param("latitude", "37.544")
+                        .param("longitude", "127.055")
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("success"))
+                .andExpect(jsonPath("$.data[0].name").value("성수 카페"));
+    }
+
+    @Test
+    @DisplayName("위도만 전달 → LOCATION_REQUIRED")
+    void search_location_invalid() throws Exception {
+        mockMvc.perform(get("/api/v1/places/search")
+                        .param("category", "CAFE")
+                        .param("latitude", "37.544")
+                )
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode")
+                        .value(PlaceErrorCase.LOCATION_REQUIRED.getErrorCode()));
+    }
+
+    @Test
+    @DisplayName("결과 없음 → PLACE_NOT_FOUND")
+    void search_empty_result() throws Exception {
+        given(placeSearchService.search(any(), any(), any(), any()))
+                .willReturn(List.of());
+
+        mockMvc.perform(get("/api/v1/places/search")
+                        .param("category", "CAFE")
+                        .param("latitude", "37.544")
+                        .param("longitude", "127.055")
+                )
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.errorCode")
+                        .value(PlaceErrorCase.PLACE_NOT_FOUND.getErrorCode()));
+    }
+}

--- a/src/test/java/com/bready/server/place/service/PlaceSearchServiceTest.java
+++ b/src/test/java/com/bready/server/place/service/PlaceSearchServiceTest.java
@@ -1,0 +1,91 @@
+package com.bready.server.place.service;
+
+import com.bready.server.global.exception.ApplicationException;
+import com.bready.server.place.domain.PlaceCategoryType;
+import com.bready.server.place.dto.PlaceSearchResponse;
+import com.bready.server.place.exception.PlaceErrorCase;
+import com.bready.server.place.external.KakaoPlaceClient;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+
+@ExtendWith(MockitoExtension.class)
+class PlaceSearchServiceTest {
+
+    @Mock
+    private KakaoPlaceClient kakaoPlaceClient;
+
+    @Spy
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    @InjectMocks
+    private PlaceSearchService placeSearchService;
+
+    @Test
+    @DisplayName("카카오 응답 파싱 성공")
+    void search_parse_success() {
+        given(kakaoPlaceClient.search(any(), any(), any(), any(), any()))
+                .willReturn("""
+                    {
+                      "documents": [
+                        {
+                          "id": "123",
+                          "place_name": "성수 카페",
+                          "road_address_name": "서울 성동구",
+                          "address_name": "서울",
+                          "x": "127.055",
+                          "y": "37.544"
+                        }
+                      ]
+                    }
+                """);
+
+        List<PlaceSearchResponse> result =
+                placeSearchService.search(
+                        PlaceCategoryType.CAFE,
+                        37.544,
+                        127.055,
+                        2000
+                );
+        assertThat(result).hasSize(1);
+        PlaceSearchResponse response = result.get(0);
+
+        assertThat(response.externalId()).isEqualTo("kakao-123");
+        assertThat(response.name()).isEqualTo("성수 카페");
+        assertThat(response.address()).isEqualTo("서울 성동구");
+        assertThat(response.latitude()).isEqualByComparingTo("37.544");
+        assertThat(response.longitude()).isEqualByComparingTo("127.055");
+        assertThat(response.isIndoor()).isTrue();
+    }
+
+    @Test
+    @DisplayName("카카오 JSON 깨짐 → KAKAO_RESPONSE_PARSE_FAILED")
+    void search_parse_fail() {
+        given(kakaoPlaceClient.search(any(), any(), any(), any(), any()))
+                .willReturn("INVALID_JSON");
+
+        assertThatThrownBy(() ->
+                placeSearchService.search(
+                        PlaceCategoryType.CAFE,
+                        37.0,
+                        127.0,
+                        2000
+                ))
+                .isInstanceOf(ApplicationException.class)
+                .extracting("errorCase")
+                .isEqualTo(PlaceErrorCase.KAKAO_RESPONSE_PARSE_FAILED);
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #17 

## 📝 작업 내용
카카오 장소 검색 기능에 대해 외부 의존성을 제거한 단위 테스트를 작성했습니다.

**1. PlaceSearchServiceTest 추가**
- 카카오 API 응답은 Mock 문자열로 대체
- 파싱 및 변환 로직만 검증
- 예외 케이스 테스트 => 런타임 예외가 아닌 도메인 예외로 매핑되는지 검증

**2. PlaceSearchControllerTest 추가**
- MockMvc 기반 컨트롤러 테스트 추가
- 정상 검색 요청 → 200 OK
- 위도/경도 하나만 전달 → LOCATION_REQUIRED
- 검색 결과 없음 → PLACE_NOT_FOUND

**=> 모든 테스트코드 통과 확인했습니다.**

## 🖼️ 스크린샷 (선택)

> UI 변경 등 시각적으로 확인할 수 있는 내용이 있다면 첨부해주세요

## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특히 봐주었으면 하는 부분이 있다면 작성해주세요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Tests**
  * 장소 검색 기능에 대한 포괄적인 테스트 스위트 추가
  * 다양한 사용 사례에 대한 검증 로직 구현

* **Chores**
  * 보안 테스트 관련 의존성 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->