### PR TITLE
[feat] 장소 후보 등록 API 구현 

### DIFF
--- a/src/main/java/com/bready/server/place/controller/PlaceCandidateController.java
+++ b/src/main/java/com/bready/server/place/controller/PlaceCandidateController.java
@@ -1,0 +1,56 @@
+package com.bready.server.place.controller;
+
+import com.bready.server.global.response.CommonResponse;
+import com.bready.server.place.dto.PlaceCandidateCreateRequest;
+import com.bready.server.place.dto.PlaceCandidateCreateResponse;
+import com.bready.server.place.service.PlaceCandidateService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/places")
+@RequiredArgsConstructor
+public class PlaceCandidateController {
+
+    private final PlaceCandidateService placeCandidateService;
+
+    @PostMapping("/candidates")
+    @Operation(
+            summary = "장소 후보 등록",
+            description = "장소 검색 결과로 선택한 장소를 특정 PlanCategory의 장소 후보로 등록합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "장소 후보 등록 성공",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 요청 (필수 값 누락, 유효하지 않은 요청 값)",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))
+            ),
+            @ApiResponse(
+                    responseCode = "409",
+                    description = "이미 해당 카테고리에 등록된 장소 후보",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))
+            )
+    })
+    public CommonResponse<PlaceCandidateCreateResponse> createCandidate(
+            @RequestBody @Valid
+            PlaceCandidateCreateRequest request
+    ) {
+        return CommonResponse.success(
+                placeCandidateService.createCandidate(request)
+        );
+    }
+}

--- a/src/main/java/com/bready/server/place/domain/Place.java
+++ b/src/main/java/com/bready/server/place/domain/Place.java
@@ -2,15 +2,16 @@ package com.bready.server.place.domain;
 
 import com.bready.server.global.entity.BaseEntity;
 import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.math.BigDecimal;
 
-@Getter
-@NoArgsConstructor
 @Entity
 @Table(name = "places")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Place extends BaseEntity {
 
     @Id
@@ -18,7 +19,7 @@ public class Place extends BaseEntity {
     private Long id;
 
     // 외부 API 장소 ID (카카오, 네이버 등)
-    @Column(name = "external_id")
+    @Column(name = "external_id", nullable = false, unique = true)
     private String externalId;
 
     @Column(nullable = false)
@@ -34,4 +35,22 @@ public class Place extends BaseEntity {
 
     @Column(name = "is_indoor")
     private Boolean isIndoor;
+
+    public static Place create(
+            String externalId,
+            String name,
+            String address,
+            BigDecimal latitude,
+            BigDecimal longitude,
+            Boolean isIndoor
+    ) {
+        Place place = new Place();
+        place.externalId = externalId;
+        place.name = name;
+        place.address = address;
+        place.latitude = latitude;
+        place.longitude = longitude;
+        place.isIndoor = isIndoor;
+        return place;
+    }
 }

--- a/src/main/java/com/bready/server/place/domain/Place.java
+++ b/src/main/java/com/bready/server/place/domain/Place.java
@@ -44,6 +44,15 @@ public class Place extends BaseEntity {
             BigDecimal longitude,
             Boolean isIndoor
     ) {
+        if (externalId == null || externalId.isBlank()) {
+            throw new IllegalArgumentException("externalId는 필수입니다.");
+        }
+        if (name == null || name.isBlank()) {
+            throw new IllegalArgumentException("name은 필수입니다.");
+        }
+        if (latitude == null || longitude == null) {
+            throw new IllegalArgumentException("latitude와 longitude는 필수입니다.");
+        }
         Place place = new Place();
         place.externalId = externalId;
         place.name = name;

--- a/src/main/java/com/bready/server/place/domain/Place.java
+++ b/src/main/java/com/bready/server/place/domain/Place.java
@@ -9,7 +9,8 @@ import lombok.NoArgsConstructor;
 import java.math.BigDecimal;
 
 @Entity
-@Table(name = "places")
+@Table(name = "places",
+        uniqueConstraints = @UniqueConstraint(name = "uk_places_external_id", columnNames = "external_id"))
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Place extends BaseEntity {

--- a/src/main/java/com/bready/server/place/domain/PlaceCandidate.java
+++ b/src/main/java/com/bready/server/place/domain/PlaceCandidate.java
@@ -3,13 +3,14 @@ package com.bready.server.place.domain;
 import com.bready.server.global.entity.BaseEntity;
 import com.bready.server.plan.domain.PlanCategory;
 import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Getter
-@NoArgsConstructor
 @Entity
 @Table(name = "place_candidates")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class PlaceCandidate extends BaseEntity {
 
     @Id
@@ -25,4 +26,14 @@ public class PlaceCandidate extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "place_id", nullable = false)
     private Place place; // Place와의 연관관계 설정 (1:N)
+
+    public static PlaceCandidate create(
+            PlanCategory category,
+            Place place
+    ) {
+        PlaceCandidate candidate = new PlaceCandidate();
+        candidate.category = category;
+        candidate.place = place;
+        return candidate;
+    }
 }

--- a/src/main/java/com/bready/server/place/domain/PlaceCandidate.java
+++ b/src/main/java/com/bready/server/place/domain/PlaceCandidate.java
@@ -8,7 +8,15 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(name = "place_candidates")
+@Table(
+        name = "place_candidates",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_category_place",
+                        columnNames = {"category_id", "place_id"}
+                )
+        }
+)
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class PlaceCandidate extends BaseEntity {

--- a/src/main/java/com/bready/server/place/domain/PlaceCandidate.java
+++ b/src/main/java/com/bready/server/place/domain/PlaceCandidate.java
@@ -31,6 +31,12 @@ public class PlaceCandidate extends BaseEntity {
             PlanCategory category,
             Place place
     ) {
+        if (category == null) {
+            throw new IllegalArgumentException("category는 필수입니다.");
+        }
+        if (place == null) {
+            throw new IllegalArgumentException("place는 필수입니다.");
+        }
         PlaceCandidate candidate = new PlaceCandidate();
         candidate.category = category;
         candidate.place = place;

--- a/src/main/java/com/bready/server/place/dto/PlaceCandidateCreateRequest.java
+++ b/src/main/java/com/bready/server/place/dto/PlaceCandidateCreateRequest.java
@@ -1,5 +1,7 @@
 package com.bready.server.place.dto;
 
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
@@ -19,8 +21,13 @@ public record PlaceCandidateCreateRequest(
         String address,
 
         @NotNull
+        @DecimalMin(value = "-90.0")
+        @DecimalMax(value = "90.0")
         BigDecimal latitude,
+
         @NotNull
+        @DecimalMin(value = "-180.0")
+        @DecimalMax(value = "180.0")
         BigDecimal longitude,
 
         Boolean isIndoor

--- a/src/main/java/com/bready/server/place/dto/PlaceCandidateCreateRequest.java
+++ b/src/main/java/com/bready/server/place/dto/PlaceCandidateCreateRequest.java
@@ -1,0 +1,27 @@
+package com.bready.server.place.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import java.math.BigDecimal;
+
+public record PlaceCandidateCreateRequest(
+        @NotNull
+        Long planId,
+        @NotNull
+        Long categoryId,
+
+        @NotBlank
+        String externalId,
+        @NotBlank
+        String name,
+
+        String address,
+
+        @NotNull
+        BigDecimal latitude,
+        @NotNull
+        BigDecimal longitude,
+
+        Boolean isIndoor
+) {}

--- a/src/main/java/com/bready/server/place/dto/PlaceCandidateCreateResponse.java
+++ b/src/main/java/com/bready/server/place/dto/PlaceCandidateCreateResponse.java
@@ -1,0 +1,11 @@
+package com.bready.server.place.dto;
+
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Builder
+public record PlaceCandidateCreateResponse(
+        Long candidateId,
+        LocalDateTime createdAt
+) {}

--- a/src/main/java/com/bready/server/place/dto/PlaceCandidateCreateResponse.java
+++ b/src/main/java/com/bready/server/place/dto/PlaceCandidateCreateResponse.java
@@ -7,5 +7,6 @@ import java.time.LocalDateTime;
 @Builder
 public record PlaceCandidateCreateResponse(
         Long candidateId,
+        PlaceSummaryResponse place,
         LocalDateTime createdAt
 ) {}

--- a/src/main/java/com/bready/server/place/dto/PlaceSummaryResponse.java
+++ b/src/main/java/com/bready/server/place/dto/PlaceSummaryResponse.java
@@ -1,0 +1,14 @@
+package com.bready.server.place.dto;
+
+import lombok.Builder;
+
+public record PlaceSummaryResponse(
+        Long id,
+        String externalId,
+        String name,
+        String address,
+        Boolean isIndoor
+) {
+    @Builder
+    public PlaceSummaryResponse {}
+}

--- a/src/main/java/com/bready/server/place/exception/PlaceErrorCase.java
+++ b/src/main/java/com/bready/server/place/exception/PlaceErrorCase.java
@@ -16,7 +16,7 @@ public enum PlaceErrorCase implements ErrorCase {
     KAKAO_SERVER_ERROR(HttpStatus.BAD_GATEWAY, 4104, "카카오 장소 서비스에 장애가 발생했습니다."),
     KAKAO_RESPONSE_PARSE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 4105, "카카오 장소 응답 파싱에 실패했습니다."),
     DUPLICATE_PLACE_CANDIDATE(HttpStatus.CONFLICT, 4106, "이미 해당 카테고리에 등록된 장소입니다."),
-    INVALID_PLACE_OR_CATEGORY(HttpStatus.BAD_REQUEST, 4107, "유효하지 않은 플랜 또는 카테고리입니다.");
+    INVALID_PLAN_OR_CATEGORY(HttpStatus.BAD_REQUEST, 4107, "유효하지 않은 플랜 또는 카테고리입니다.");
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/bready/server/place/exception/PlaceErrorCase.java
+++ b/src/main/java/com/bready/server/place/exception/PlaceErrorCase.java
@@ -17,7 +17,8 @@ public enum PlaceErrorCase implements ErrorCase {
     KAKAO_RESPONSE_PARSE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 4105, "카카오 장소 응답 파싱에 실패했습니다."),
     DUPLICATE_PLACE_CANDIDATE(HttpStatus.CONFLICT, 4106, "이미 해당 카테고리에 등록된 장소입니다."),
     INVALID_PLAN_OR_CATEGORY(HttpStatus.BAD_REQUEST, 4107, "유효하지 않은 플랜 또는 카테고리입니다."),
-    DUPLICATE_PLACE(HttpStatus.CONFLICT, 4108, "이미 등록된 장소입니다.");
+    DUPLICATE_PLACE(HttpStatus.CONFLICT, 4108, "이미 등록된 장소입니다."),
+    PLACE_SAVE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 4501, "장소 저장에 실패했습니다.");
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/bready/server/place/exception/PlaceErrorCase.java
+++ b/src/main/java/com/bready/server/place/exception/PlaceErrorCase.java
@@ -14,7 +14,10 @@ public enum PlaceErrorCase implements ErrorCase {
     PLACE_NOT_FOUND(HttpStatus.NOT_FOUND, 4102, "조건에 맞는 장소를 찾을 수 없습니다."),
     KAKAO_CLIENT_ERROR(HttpStatus.BAD_GATEWAY, 4103, "카카오 장소 검색 요청이 잘못되었습니다."),
     KAKAO_SERVER_ERROR(HttpStatus.BAD_GATEWAY, 4104, "카카오 장소 서비스에 장애가 발생했습니다."),
-    KAKAO_RESPONSE_PARSE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 4105, "카카오 장소 응답 파싱에 실패했습니다.");
+    KAKAO_RESPONSE_PARSE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 4105, "카카오 장소 응답 파싱에 실패했습니다."),
+    DUPLICATE_PLACE_CANDIDATE(HttpStatus.CONFLICT, 4106, "이미 해당 카테고리에 등록된 장소입니다."),
+    INVALID_PLACE_OR_CATEGORY(HttpStatus.BAD_REQUEST, 4107, "유효하지 않은 플랜 또는 카테고리입니다.");
+
 
     private final HttpStatus httpStatus;
     private final Integer errorCode;

--- a/src/main/java/com/bready/server/place/exception/PlaceErrorCase.java
+++ b/src/main/java/com/bready/server/place/exception/PlaceErrorCase.java
@@ -16,7 +16,8 @@ public enum PlaceErrorCase implements ErrorCase {
     KAKAO_SERVER_ERROR(HttpStatus.BAD_GATEWAY, 4104, "카카오 장소 서비스에 장애가 발생했습니다."),
     KAKAO_RESPONSE_PARSE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 4105, "카카오 장소 응답 파싱에 실패했습니다."),
     DUPLICATE_PLACE_CANDIDATE(HttpStatus.CONFLICT, 4106, "이미 해당 카테고리에 등록된 장소입니다."),
-    INVALID_PLAN_OR_CATEGORY(HttpStatus.BAD_REQUEST, 4107, "유효하지 않은 플랜 또는 카테고리입니다.");
+    INVALID_PLAN_OR_CATEGORY(HttpStatus.BAD_REQUEST, 4107, "유효하지 않은 플랜 또는 카테고리입니다."),
+    DUPLICATE_PLACE(HttpStatus.CONFLICT, 4108, "이미 등록된 장소입니다.");
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/bready/server/place/repository/PlaceCandidateRepository.java
+++ b/src/main/java/com/bready/server/place/repository/PlaceCandidateRepository.java
@@ -1,10 +1,7 @@
 package com.bready.server.place.repository;
 
-import com.bready.server.place.domain.Place;
 import com.bready.server.place.domain.PlaceCandidate;
-import com.bready.server.plan.domain.PlanCategory;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PlaceCandidateRepository extends JpaRepository<PlaceCandidate, Long> {
-    boolean existsByCategoryAndPlace(PlanCategory category, Place place);
 }

--- a/src/main/java/com/bready/server/place/repository/PlaceCandidateRepository.java
+++ b/src/main/java/com/bready/server/place/repository/PlaceCandidateRepository.java
@@ -1,7 +1,10 @@
 package com.bready.server.place.repository;
 
+import com.bready.server.place.domain.Place;
 import com.bready.server.place.domain.PlaceCandidate;
+import com.bready.server.plan.domain.PlanCategory;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PlaceCandidateRepository extends JpaRepository<PlaceCandidate, Long> {
+    boolean existsByCategoryAndPlace(PlanCategory category, Place place);
 }

--- a/src/main/java/com/bready/server/place/repository/PlaceRepository.java
+++ b/src/main/java/com/bready/server/place/repository/PlaceRepository.java
@@ -3,5 +3,8 @@ package com.bready.server.place.repository;
 import com.bready.server.place.domain.Place;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface PlaceRepository extends JpaRepository<Place, Long> {
+    Optional<Place> findByExternalId(String externalId);
 }

--- a/src/main/java/com/bready/server/place/service/PlaceCandidateService.java
+++ b/src/main/java/com/bready/server/place/service/PlaceCandidateService.java
@@ -37,7 +37,7 @@ public class PlaceCandidateService {
         // PlaceCandidate 저장 -> 동시성 중복은 DB 유니크로 차단
         PlaceCandidate saved;
         try {
-            saved = placeCandidateRepository.save(PlaceCandidate.create(category, place));
+            saved = placeCandidateRepository.saveAndFlush(PlaceCandidate.create(category, place));
         } catch (DataIntegrityViolationException e) {
             throw ApplicationException.from(PlaceErrorCase.DUPLICATE_PLACE_CANDIDATE);
         }

--- a/src/main/java/com/bready/server/place/service/PlaceCandidateService.java
+++ b/src/main/java/com/bready/server/place/service/PlaceCandidateService.java
@@ -5,76 +5,53 @@ import com.bready.server.place.domain.Place;
 import com.bready.server.place.domain.PlaceCandidate;
 import com.bready.server.place.dto.PlaceCandidateCreateRequest;
 import com.bready.server.place.dto.PlaceCandidateCreateResponse;
+import com.bready.server.place.dto.PlaceSummaryResponse;
 import com.bready.server.place.exception.PlaceErrorCase;
 import com.bready.server.place.repository.PlaceCandidateRepository;
-import com.bready.server.place.repository.PlaceRepository;
 import com.bready.server.plan.domain.PlanCategory;
 import com.bready.server.plan.repository.PlanCategoryRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class PlaceCandidateService {
 
-    private final PlaceRepository placeRepository;
-    private final PlaceCandidateRepository placeCandidateRepository;
     private final PlanCategoryRepository planCategoryRepository;
+    private final PlaceCandidateRepository placeCandidateRepository;
+    private final PlacePersistenceService placePersistenceService;
 
     @Transactional
     public PlaceCandidateCreateResponse createCandidate(PlaceCandidateCreateRequest request) {
 
-        // planId + categoryId 연관 검증
+        // planId + categoryId 매칭 검증
         PlanCategory category = planCategoryRepository
                 .findByIdAndPlan_Id(request.categoryId(), request.planId())
-                .orElseThrow(() ->
-                        ApplicationException.from(PlaceErrorCase.INVALID_PLAN_OR_CATEGORY)
-                );
+                .orElseThrow(() -> ApplicationException.from(PlaceErrorCase.INVALID_PLAN_OR_CATEGORY));
 
-        Place place = getOrCreatePlace(request);
+        // Place는 중복이면 재사용 (REQUIRES_NEW로 분리된 빈 호출)
+        Place place = placePersistenceService.getOrCreate(request);
 
-        // 후보 저장 (중복은 DB 유니크 제약으로 차단)
+        // PlaceCandidate 저장 -> 동시성 중복은 DB 유니크로 차단
         PlaceCandidate saved;
         try {
-            saved = placeCandidateRepository.save(
-                    PlaceCandidate.create(category, place)
-            );
+            saved = placeCandidateRepository.save(PlaceCandidate.create(category, place));
         } catch (DataIntegrityViolationException e) {
             throw ApplicationException.from(PlaceErrorCase.DUPLICATE_PLACE_CANDIDATE);
         }
 
         return PlaceCandidateCreateResponse.builder()
                 .candidateId(saved.getId())
+                .place(PlaceSummaryResponse.builder()
+                        .id(place.getId())
+                        .externalId(place.getExternalId())
+                        .name(place.getName())
+                        .address(place.getAddress())
+                        .isIndoor(place.getIsIndoor())
+                        .build())
                 .createdAt(saved.getCreatedAt())
                 .build();
-    }
-
-    // Place 조회 또는 생성은 별도 트랜잭션으로 분리
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
-    protected Place getOrCreatePlace(PlaceCandidateCreateRequest request) {
-        try {
-            return placeRepository.findByExternalId(request.externalId())
-                    .orElseGet(() ->
-                            placeRepository.save(
-                                    Place.create(
-                                            request.externalId(),
-                                            request.name(),
-                                            request.address(),
-                                            request.latitude(),
-                                            request.longitude(),
-                                            request.isIndoor()
-                                    )
-                            )
-                    );
-        } catch (DataIntegrityViolationException e) {
-            // 다른 트랜잭션이 먼저 insert 한 경우
-            return placeRepository.findByExternalId(request.externalId())
-                    .orElseThrow(() ->
-                            ApplicationException.from(PlaceErrorCase.DUPLICATE_PLACE)
-                    );
-        }
     }
 }

--- a/src/main/java/com/bready/server/place/service/PlaceCandidateService.java
+++ b/src/main/java/com/bready/server/place/service/PlaceCandidateService.java
@@ -1,0 +1,69 @@
+package com.bready.server.place.service;
+
+import com.bready.server.global.exception.ApplicationException;
+import com.bready.server.place.domain.Place;
+import com.bready.server.place.domain.PlaceCandidate;
+import com.bready.server.place.dto.PlaceCandidateCreateRequest;
+import com.bready.server.place.dto.PlaceCandidateCreateResponse;
+import com.bready.server.place.dto.PlaceSummaryResponse;
+import com.bready.server.place.exception.PlaceErrorCase;
+import com.bready.server.place.repository.PlaceCandidateRepository;
+import com.bready.server.place.repository.PlaceRepository;
+import com.bready.server.plan.domain.PlanCategory;
+import com.bready.server.plan.repository.PlanCategoryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class PlaceCandidateService {
+
+    private final PlaceRepository placeRepository;
+    private final PlaceCandidateRepository placeCandidateRepository;
+    private final PlanCategoryRepository planCategoryRepository;
+
+    @Transactional
+    public PlaceCandidateCreateResponse createCandidate(PlaceCandidateCreateRequest request) {
+        PlanCategory category = planCategoryRepository
+                .findByIdAndPlan_Id(request.categoryId(), request.planId())
+                .orElseThrow(() -> ApplicationException.from(PlaceErrorCase.INVALID_PLAN_OR_CATEGORY));
+
+        Place place = placeRepository.findByExternalId(request.externalId())
+                .orElseGet(() -> placeRepository.save(
+                        Place.create(
+                                request.externalId(),
+                                request.name(),
+                                request.address(),
+                                request.latitude(),
+                                request.longitude(),
+                                request.isIndoor()
+                        )
+                ));
+
+        // category + place 중복 방지
+        if (placeCandidateRepository.existsByCategoryAndPlace(category, place)) {
+            throw ApplicationException.from(PlaceErrorCase.DUPLICATE_PLACE_CANDIDATE);
+        }
+
+        // 장소 후보 저장
+        PlaceCandidate saved = placeCandidateRepository.save(
+                PlaceCandidate.create(category, place)
+        );
+
+        return PlaceCandidateCreateResponse.builder()
+                .candidateId(saved.getId())
+                .place(
+                        PlaceSummaryResponse.builder()
+                                .id(place.getId())
+                                .externalId(place.getExternalId())
+                                .name(place.getName())
+                                .address(place.getAddress())
+                                .isIndoor(place.getIsIndoor())
+                                .build()
+                )
+                .createdAt(saved.getCreatedAt())
+                .build();
+    }
+}
+

--- a/src/main/java/com/bready/server/place/service/PlaceCandidateService.java
+++ b/src/main/java/com/bready/server/place/service/PlaceCandidateService.java
@@ -26,7 +26,7 @@ public class PlaceCandidateService {
     @Transactional
     public PlaceCandidateCreateResponse createCandidate(PlaceCandidateCreateRequest request) {
 
-        PlanCategory category = planCategoryRepository.findById(request.categoryId())
+        PlanCategory category = planCategoryRepository.findByIdAndPlan_Id(request.categoryId(), request.planId())
                 .orElseThrow(() -> ApplicationException.from(PlaceErrorCase.INVALID_PLAN_OR_CATEGORY));
 
         Place place;

--- a/src/main/java/com/bready/server/place/service/PlacePersistenceService.java
+++ b/src/main/java/com/bready/server/place/service/PlacePersistenceService.java
@@ -1,0 +1,40 @@
+package com.bready.server.place.service;
+
+import com.bready.server.global.exception.ApplicationException;
+import com.bready.server.place.domain.Place;
+import com.bready.server.place.dto.PlaceCandidateCreateRequest;
+import com.bready.server.place.exception.PlaceErrorCase;
+import com.bready.server.place.repository.PlaceRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class PlacePersistenceService {
+
+    private final PlaceRepository placeRepository;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public Place getOrCreate(PlaceCandidateCreateRequest request) {
+        try {
+            return placeRepository.findByExternalId(request.externalId())
+                    .orElseGet(() -> placeRepository.save(
+                            Place.create(
+                                    request.externalId(),
+                                    request.name(),
+                                    request.address(),
+                                    request.latitude(),
+                                    request.longitude(),
+                                    request.isIndoor()
+                            )
+                    ));
+        } catch (DataIntegrityViolationException e) {
+            // 다른 트랜잭션이 먼저 insert 한 경우는 재조회로 해결
+            return placeRepository.findByExternalId(request.externalId())
+                    .orElseThrow(() -> ApplicationException.from(PlaceErrorCase.PLACE_SAVE_FAILED));
+        }
+    }
+}

--- a/src/main/java/com/bready/server/place/service/PlacePersistenceService.java
+++ b/src/main/java/com/bready/server/place/service/PlacePersistenceService.java
@@ -21,7 +21,7 @@ public class PlacePersistenceService {
     public Place getOrCreate(PlaceCandidateCreateRequest request) {
         try {
             return placeRepository.findByExternalId(request.externalId())
-                    .orElseGet(() -> placeRepository.save(
+                    .orElseGet(() -> placeRepository.saveAndFlush(
                             Place.create(
                                     request.externalId(),
                                     request.name(),

--- a/src/main/java/com/bready/server/plan/repository/PlanCategoryRepository.java
+++ b/src/main/java/com/bready/server/plan/repository/PlanCategoryRepository.java
@@ -3,5 +3,9 @@ package com.bready.server.plan.repository;
 import com.bready.server.plan.domain.PlanCategory;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface PlanCategoryRepository extends JpaRepository<PlanCategory, Long> {
+    // 장소 후보쪽에서 category가 plan에 속하는지 검증하기 위해서 추가
+    Optional<PlanCategory> findByIdAndPlan_Id(Long categoryId, Long planId);
 }

--- a/src/main/java/com/bready/server/plan/repository/PlanCategoryRepository.java
+++ b/src/main/java/com/bready/server/plan/repository/PlanCategoryRepository.java
@@ -7,5 +7,5 @@ import java.util.Optional;
 
 public interface PlanCategoryRepository extends JpaRepository<PlanCategory, Long> {
     // 장소 후보쪽에서 category가 plan에 속하는지 검증하기 위해서 추가
-    Optional<PlanCategory> findByIdAndPlan_Id(Long categoryId, Long planId);
+    Optional<PlanCategory> findByIdAndPlan_Id(Long id, Long planId);
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #19 

## 📝 작업 내용

**장소 후보 등록 API 구현 (POST /api/v1/places/candidates)**
- 사용자가 검색한 외부 장소를 PlanCategory 기준으로 후보 등록
- 요청 시 전달받은 externalId 기준으로 Place 중복 저장 방지
- 동일한 category + place 조합에 대해 중복 후보 등록 방지
- 중복 등록 시 예외 반환

## 🖼️ 스크린샷 (선택)
### 장소 후보 등록 성공
<img width="1473" height="943" alt="장소후보등록성공" src="https://github.com/user-attachments/assets/2c347aa1-dbf1-41c5-a7d1-7e8efafc0835" />

### 장소 후보 등록 실패 (존재하지 않는 카테고리 ID 넣었을때)
<img width="1461" height="944" alt="장소후보등록실패" src="https://github.com/user-attachments/assets/052414c4-58b7-46fb-b974-d41ed8d3ac72" />

## 💬 리뷰 요구사항 (선택)

> 현재 일정 생성 API가 존재하지 않아서 db에 임시로 데이터 넣어서 Swagger 테스트 진행하였습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 장소 후보 생성 POST 엔드포인트 추가 — 플랜 내 특정 카테고리에 장소 제안 가능.
  * 생성 응답에 후보 ID, 장소 요약 및 생성 시각 포함.

* **개선**
  * 외부 ID, 위도/경도 등 입력 유효성 검사 강화.
  * 중복 장소·중복 후보 감지 및 명확한 오류(400/409) 응답 추가.
  * 장소 조회/생성 흐름 개선으로 일관된 저장 처리 보장.

* **버그 픽스**
  * 중복 저장 시 적절한 충돌 처리 및 오류 매핑 추가.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->