### PR TITLE
[feat] 대표 장소 선택 API 구현 

### DIFF
--- a/src/main/java/com/bready/server/place/controller/PlaceCandidateController.java
+++ b/src/main/java/com/bready/server/place/controller/PlaceCandidateController.java
@@ -62,7 +62,7 @@ public class PlaceCandidateController {
             @ApiResponse(
                     responseCode = "200",
                     description = "대표 장소 후보 선택 성공",
-                    content = @Content(schema = @Schema(implementation = PlaceCandidateRepresentativeResponse.class))
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))
             ),
             @ApiResponse(
                     responseCode = "404",

--- a/src/main/java/com/bready/server/place/controller/PlaceCandidateController.java
+++ b/src/main/java/com/bready/server/place/controller/PlaceCandidateController.java
@@ -3,6 +3,7 @@ package com.bready.server.place.controller;
 import com.bready.server.global.response.CommonResponse;
 import com.bready.server.place.dto.PlaceCandidateCreateRequest;
 import com.bready.server.place.dto.PlaceCandidateCreateResponse;
+import com.bready.server.place.dto.PlaceCandidateRepresentativeResponse;
 import com.bready.server.place.service.PlaceCandidateService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -11,10 +12,8 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+import io.swagger.v3.oas.annotations.Parameter;
 
 @RestController
 @RequestMapping("/api/v1/places")
@@ -51,6 +50,37 @@ public class PlaceCandidateController {
     ) {
         return CommonResponse.success(
                 placeCandidateService.createCandidate(request)
+        );
+    }
+
+    @PostMapping("/candidates/{candidateId}/representative")
+    @Operation(
+            summary = "대표 장소 후보 선택",
+            description = "특정 카테고리에서 대표로 사용할 장소 후보를 선택합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "대표 장소 후보 선택 성공",
+                    content = @Content(schema = @Schema(implementation = PlaceCandidateRepresentativeResponse.class))
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "존재하지 않는 장소 후보",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))
+            ),
+            @ApiResponse(
+                    responseCode = "409",
+                    description = "이미 대표 장소로 선택된 후보",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))
+            )
+    })
+    public CommonResponse<PlaceCandidateRepresentativeResponse> setRepresentative(
+            @Parameter(description = "대표로 선택할 장소 후보 ID", example = "12", required = true)
+            @PathVariable Long candidateId
+    ) {
+        return CommonResponse.success(
+                placeCandidateService.setRepresentative(candidateId)
         );
     }
 }

--- a/src/main/java/com/bready/server/place/dto/PlaceCandidateRepresentativeResponse.java
+++ b/src/main/java/com/bready/server/place/dto/PlaceCandidateRepresentativeResponse.java
@@ -1,0 +1,12 @@
+package com.bready.server.place.dto;
+
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Builder
+public record PlaceCandidateRepresentativeResponse(
+        Long categoryId,
+        Long representativeCandidateId,
+        LocalDateTime changedAt
+) {}

--- a/src/main/java/com/bready/server/place/exception/PlaceErrorCase.java
+++ b/src/main/java/com/bready/server/place/exception/PlaceErrorCase.java
@@ -18,7 +18,9 @@ public enum PlaceErrorCase implements ErrorCase {
     DUPLICATE_PLACE_CANDIDATE(HttpStatus.CONFLICT, 4106, "이미 해당 카테고리에 등록된 장소입니다."),
     INVALID_PLAN_OR_CATEGORY(HttpStatus.BAD_REQUEST, 4107, "유효하지 않은 플랜 또는 카테고리입니다."),
     DUPLICATE_PLACE(HttpStatus.CONFLICT, 4108, "이미 등록된 장소입니다."),
-    PLACE_SAVE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 4501, "장소 저장에 실패했습니다.");
+    PLACE_SAVE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 4109, "장소 저장에 실패했습니다."),
+    PLACE_CANDIDATE_NOT_FOUND(HttpStatus.NOT_FOUND, 4110, "존재하지 않는 장소 후보 입니다."),
+    ALREADY_REPRESENTATIVE_CANDIDATE(HttpStatus.CONFLICT, 4111, "이미 대표 장소 후보 입니다.");
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/bready/server/place/repository/PlaceCandidateRepository.java
+++ b/src/main/java/com/bready/server/place/repository/PlaceCandidateRepository.java
@@ -2,6 +2,17 @@ package com.bready.server.place.repository;
 
 import com.bready.server.place.domain.PlaceCandidate;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.Optional;
 
 public interface PlaceCandidateRepository extends JpaRepository<PlaceCandidate, Long> {
+    @Query("""
+        select pc
+        from PlaceCandidate pc
+        join fetch pc.category c
+        join fetch pc.place p
+        where pc.id = :candidateId
+    """)
+    Optional<PlaceCandidate> findByIdWithCategoryAndPlace(Long candidateId);
 }

--- a/src/main/java/com/bready/server/place/service/PlaceCandidateService.java
+++ b/src/main/java/com/bready/server/place/service/PlaceCandidateService.java
@@ -77,7 +77,7 @@ public class PlaceCandidateService {
         Long categoryId = category.getId();
 
         CategoryState state = categoryStateRepository
-                .findByCategory_Id(categoryId)
+                .findByCategory_IdForUpdate(categoryId)
                 .orElse(null);
 
         if (state == null) {

--- a/src/main/java/com/bready/server/place/service/PlaceCandidateService.java
+++ b/src/main/java/com/bready/server/place/service/PlaceCandidateService.java
@@ -5,15 +5,22 @@ import com.bready.server.place.domain.Place;
 import com.bready.server.place.domain.PlaceCandidate;
 import com.bready.server.place.dto.PlaceCandidateCreateRequest;
 import com.bready.server.place.dto.PlaceCandidateCreateResponse;
+import com.bready.server.place.dto.PlaceCandidateRepresentativeResponse;
 import com.bready.server.place.dto.PlaceSummaryResponse;
 import com.bready.server.place.exception.PlaceErrorCase;
 import com.bready.server.place.repository.PlaceCandidateRepository;
+import com.bready.server.plan.domain.CategorySelectionLog;
+import com.bready.server.plan.domain.CategoryState;
 import com.bready.server.plan.domain.PlanCategory;
+import com.bready.server.plan.repository.CategorySelectionLogRepository;
+import com.bready.server.plan.repository.CategoryStateRepository;
 import com.bready.server.plan.repository.PlanCategoryRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
 
 @Service
 @RequiredArgsConstructor
@@ -22,6 +29,8 @@ public class PlaceCandidateService {
     private final PlanCategoryRepository planCategoryRepository;
     private final PlaceCandidateRepository placeCandidateRepository;
     private final PlacePersistenceService placePersistenceService;
+    private final CategoryStateRepository categoryStateRepository;
+    private final CategorySelectionLogRepository categorySelectionLogRepository;
 
     @Transactional
     public PlaceCandidateCreateResponse createCandidate(PlaceCandidateCreateRequest request) {
@@ -52,6 +61,51 @@ public class PlaceCandidateService {
                         .isIndoor(place.getIsIndoor())
                         .build())
                 .createdAt(saved.getCreatedAt())
+                .build();
+    }
+
+    @Transactional
+    public PlaceCandidateRepresentativeResponse setRepresentative(Long candidateId) {
+
+        PlaceCandidate candidate = placeCandidateRepository
+                .findByIdWithCategoryAndPlace(candidateId)
+                .orElseThrow(() ->
+                        ApplicationException.from(PlaceErrorCase.PLACE_CANDIDATE_NOT_FOUND)
+                );
+
+        PlanCategory category = candidate.getCategory();
+        Long categoryId = category.getId();
+
+        CategoryState state = categoryStateRepository
+                .findByCategory_Id(categoryId)
+                .orElse(null);
+
+        if (state == null) {
+            // 첫 대표 지정
+            state = CategoryState.create(category, candidateId);
+            categoryStateRepository.save(state);
+        } else {
+            // 이미 대표인 경우
+            if (state.isRepresentative(candidateId)) {
+                throw ApplicationException.from(
+                        PlaceErrorCase.ALREADY_REPRESENTATIVE_CANDIDATE
+                );
+            }
+            state.changeRepresentative(candidateId);
+        }
+
+        categorySelectionLogRepository.save(
+                CategorySelectionLog.of(
+                        categoryId,
+                        candidateId,
+                        LocalDateTime.now()
+                )
+        );
+
+        return PlaceCandidateRepresentativeResponse.builder()
+                .categoryId(categoryId)
+                .representativeCandidateId(candidateId)
+                .changedAt(state.getUpdatedAt())
                 .build();
     }
 }

--- a/src/main/java/com/bready/server/plan/domain/CategoryState.java
+++ b/src/main/java/com/bready/server/plan/domain/CategoryState.java
@@ -28,4 +28,21 @@ public class CategoryState {
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "category_id", nullable = false, unique = true)
     private PlanCategory category; // PlanCategory와의 연관관계 설정 (1:1)
+
+    public static CategoryState create(PlanCategory category, Long representativeCandidateId) {
+        CategoryState state = new CategoryState();
+        state.category = category;
+        state.currentCandidateId = representativeCandidateId;
+        state.updatedAt = LocalDateTime.now();
+        return state;
+    }
+
+    public void changeRepresentative(Long representativeCandidateId) {
+        this.currentCandidateId = representativeCandidateId;
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    public boolean isRepresentative(Long candidateId) {
+        return this.currentCandidateId != null && this.currentCandidateId.equals(candidateId);
+    }
 }

--- a/src/main/java/com/bready/server/plan/repository/CategoryStateRepository.java
+++ b/src/main/java/com/bready/server/plan/repository/CategoryStateRepository.java
@@ -3,5 +3,8 @@ package com.bready.server.plan.repository;
 import com.bready.server.plan.domain.CategoryState;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface CategoryStateRepository extends JpaRepository<CategoryState, Long> {
+    Optional<CategoryState> findByCategory_Id(Long categoryId);
 }

--- a/src/main/java/com/bready/server/plan/repository/CategoryStateRepository.java
+++ b/src/main/java/com/bready/server/plan/repository/CategoryStateRepository.java
@@ -1,10 +1,24 @@
 package com.bready.server.plan.repository;
 
 import com.bready.server.plan.domain.CategoryState;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface CategoryStateRepository extends JpaRepository<CategoryState, Long> {
     Optional<CategoryState> findByCategory_Id(Long categoryId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE) // 비관적 락 적용 (동시성 제어)
+    @Query("""
+        select cs
+        from CategoryState cs
+        where cs.category.id = :categoryId
+    """)
+    Optional<CategoryState> findByCategory_IdForUpdate(
+            @Param("categoryId") Long categoryId
+    );
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #21 

## 📝 작업 내용

> 후보로 등록된 여러개의 장소중에서 대표 장소를 선택할 수 있도록 해당 API를 구현했습니다. 

## 🖼️ 스크린샷 (선택)
### 대표 장소 선택 (등록) 성공
<img width="1466" height="946" alt="대표장소선택성공" src="https://github.com/user-attachments/assets/94b8f9e6-01a5-41ac-a8c8-868eaea3d067" />

### 대표 장소 선택 실패 -> candidateId 존재 X
<img width="1463" height="946" alt="대표장소선택실패" src="https://github.com/user-attachments/assets/016bc8f4-4ace-423c-a71c-48e773ccf2e5" />

## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특히 봐주었으면 하는 부분이 있다면 작성해주세요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 장소 후보를 대표 후보로 지정하는 신규 API 추가 — 지정 시 변경 시각을 포함해 결과 반환
  * 대표 후보 상태를 생성·갱신하는 흐름과 선택 이력 기록 기능 추가

* **버그 수정 / 개선**
  * 후보 미존재 및 이미 대표인 경우에 대한 명확한 오류 응답(404, 409) 및 동시성 안전성 개선

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->