### PR TITLE
[feat] 장소 후보 삭제 API 구현 

### DIFF
--- a/src/main/java/com/bready/server/place/controller/PlaceCandidateController.java
+++ b/src/main/java/com/bready/server/place/controller/PlaceCandidateController.java
@@ -3,9 +3,11 @@ package com.bready.server.place.controller;
 import com.bready.server.global.response.CommonResponse;
 import com.bready.server.place.dto.PlaceCandidateCreateRequest;
 import com.bready.server.place.dto.PlaceCandidateCreateResponse;
+import com.bready.server.place.dto.PlaceCandidateDeleteResponse;
 import com.bready.server.place.dto.PlaceCandidateRepresentativeResponse;
 import com.bready.server.place.service.PlaceCandidateService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -13,7 +15,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
-import io.swagger.v3.oas.annotations.Parameter;
 
 @RestController
 @RequestMapping("/api/v1/places")
@@ -82,5 +83,34 @@ public class PlaceCandidateController {
         return CommonResponse.success(
                 placeCandidateService.setRepresentative(candidateId)
         );
+    }
+
+    @DeleteMapping("/candidates/{candidateId}")
+    @Operation(
+            summary = "장소 후보 삭제",
+            description = "특정 카테고리에 등록된 장소 후보를 삭제합니다. (대표 후보로 선택된 장소는 삭제 불가)"
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "삭제 성공",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "존재하지 않는 후보",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))
+            ),
+            @ApiResponse(
+                    responseCode = "409",
+                    description = "대표 장소는 삭제 불가",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))
+            )
+    })
+    public CommonResponse<PlaceCandidateDeleteResponse> deleteCandidate(
+            @Parameter(description = "삭제할 장소 후보 ID", example = "12", required = true)
+            @PathVariable Long candidateId
+    ) {
+        return CommonResponse.success(placeCandidateService.deleteCandidate(candidateId));
     }
 }

--- a/src/main/java/com/bready/server/place/controller/PlaceCandidateController.java
+++ b/src/main/java/com/bready/server/place/controller/PlaceCandidateController.java
@@ -13,11 +13,14 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/v1/places")
+@Validated
 @RequiredArgsConstructor
 public class PlaceCandidateController {
 
@@ -78,6 +81,7 @@ public class PlaceCandidateController {
     })
     public CommonResponse<PlaceCandidateRepresentativeResponse> setRepresentative(
             @Parameter(description = "대표로 선택할 장소 후보 ID", example = "12", required = true)
+            @Positive
             @PathVariable Long candidateId
     ) {
         return CommonResponse.success(
@@ -109,6 +113,7 @@ public class PlaceCandidateController {
     })
     public CommonResponse<PlaceCandidateDeleteResponse> deleteCandidate(
             @Parameter(description = "삭제할 장소 후보 ID", example = "12", required = true)
+            @Positive
             @PathVariable Long candidateId
     ) {
         return CommonResponse.success(placeCandidateService.deleteCandidate(candidateId));

--- a/src/main/java/com/bready/server/place/domain/PlaceCandidate.java
+++ b/src/main/java/com/bready/server/place/domain/PlaceCandidate.java
@@ -6,6 +6,7 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
 
 @Entity
 @Table(
@@ -17,6 +18,7 @@ import lombok.NoArgsConstructor;
                 )
         }
 )
+@SQLRestriction("deleted_at IS NULL")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class PlaceCandidate extends BaseEntity {

--- a/src/main/java/com/bready/server/place/dto/PlaceCandidateDeleteResponse.java
+++ b/src/main/java/com/bready/server/place/dto/PlaceCandidateDeleteResponse.java
@@ -1,0 +1,10 @@
+package com.bready.server.place.dto;
+
+import lombok.Builder;
+import java.time.LocalDateTime;
+
+@Builder
+public record PlaceCandidateDeleteResponse(
+        Long candidateId,
+        LocalDateTime deletedAt
+) {}

--- a/src/main/java/com/bready/server/place/exception/PlaceErrorCase.java
+++ b/src/main/java/com/bready/server/place/exception/PlaceErrorCase.java
@@ -20,7 +20,8 @@ public enum PlaceErrorCase implements ErrorCase {
     DUPLICATE_PLACE(HttpStatus.CONFLICT, 4108, "이미 등록된 장소입니다."),
     PLACE_SAVE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 4109, "장소 저장에 실패했습니다."),
     PLACE_CANDIDATE_NOT_FOUND(HttpStatus.NOT_FOUND, 4110, "존재하지 않는 장소 후보 입니다."),
-    ALREADY_REPRESENTATIVE_CANDIDATE(HttpStatus.CONFLICT, 4111, "이미 대표 장소 후보 입니다.");
+    ALREADY_REPRESENTATIVE_CANDIDATE(HttpStatus.CONFLICT, 4111, "이미 대표 장소 후보 입니다."),
+    REPRESENTATIVE_CANDIDATE_CANNOT_DELETE(HttpStatus.CONFLICT, 4091, "대표 장소는 삭제할 수 없습니다.");
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/bready/server/place/exception/PlaceErrorCase.java
+++ b/src/main/java/com/bready/server/place/exception/PlaceErrorCase.java
@@ -21,7 +21,7 @@ public enum PlaceErrorCase implements ErrorCase {
     PLACE_SAVE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 4109, "장소 저장에 실패했습니다."),
     PLACE_CANDIDATE_NOT_FOUND(HttpStatus.NOT_FOUND, 4110, "존재하지 않는 장소 후보 입니다."),
     ALREADY_REPRESENTATIVE_CANDIDATE(HttpStatus.CONFLICT, 4111, "이미 대표 장소 후보 입니다."),
-    REPRESENTATIVE_CANDIDATE_CANNOT_DELETE(HttpStatus.CONFLICT, 4091, "대표 장소는 삭제할 수 없습니다.");
+    REPRESENTATIVE_CANDIDATE_CANNOT_DELETE(HttpStatus.CONFLICT, 4112, "대표 장소는 삭제할 수 없습니다.");
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/bready/server/place/repository/PlaceCandidateRepository.java
+++ b/src/main/java/com/bready/server/place/repository/PlaceCandidateRepository.java
@@ -15,4 +15,12 @@ public interface PlaceCandidateRepository extends JpaRepository<PlaceCandidate, 
         where pc.id = :candidateId
     """)
     Optional<PlaceCandidate> findByIdWithCategoryAndPlace(Long candidateId);
+
+    @Query("""
+        select pc
+        from PlaceCandidate pc
+        join fetch pc.category c
+        where pc.id = :candidateId
+    """)
+    Optional<PlaceCandidate> findByIdWithCategory(Long candidateId);
 }

--- a/src/main/java/com/bready/server/place/service/PlaceCandidateService.java
+++ b/src/main/java/com/bready/server/place/service/PlaceCandidateService.java
@@ -121,11 +121,11 @@ public class PlaceCandidateService {
             throw ApplicationException.from(PlaceErrorCase.REPRESENTATIVE_CANDIDATE_CANNOT_DELETE);
         }
 
-        placeCandidateRepository.delete(candidate);
+        candidate.softDelete();
 
         return PlaceCandidateDeleteResponse.builder()
                 .candidateId(candidateId)
-                .deletedAt(LocalDateTime.now())
+                .deletedAt(candidate.getDeletedAt())
                 .build();
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #25 

## 📝 작업 내용

> 후보로 등록한 장소중에서 삭제하고 싶은 장소의 후보를 삭제합니다. (soft delete)

## 🖼️ 스크린샷 (선택)
### 후보 장소 삭제 성공
<img width="1454" height="944" alt="후보장소삭제성공" src="https://github.com/user-attachments/assets/9f2c44e6-edbb-429e-bda2-8f9cd8c20c6f" />

### 후보 장소 삭제 실패 (대표 장소로 저장된 후보)
<img width="1453" height="945" alt="대표장소삭제불가" src="https://github.com/user-attachments/assets/82895d2e-3b5e-403b-bf74-ba6646889953" />


## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특히 봐주었으면 하는 부분이 있다면 작성해주세요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 장소 후보 삭제 API 추가 — 삭제 시 후보 ID와 삭제 시각을 반환
* **버그 수정 / 검증**
  * 대표 장소인 후보의 삭제 시도에 대한 오류 처리 추가
  * 요청 파라미터 검증 강화 및 API 문서화(스웨거) 개선

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->