### PR TITLE
[feat] 트리거 생성 API 구현 

### DIFF
--- a/src/main/java/com/bready/server/stats/service/PlanStatsService.java
+++ b/src/main/java/com/bready/server/stats/service/PlanStatsService.java
@@ -6,4 +6,9 @@ import org.springframework.stereotype.Service;
 @Service
 @RequiredArgsConstructor
 public class PlanStatsService {
+
+    // TODO(stats): PlanStats 도메인/테이블 구현 후 planId 기준 total_triggers++ 반영 필요
+    public void increaseTriggerCount(Long planId) {
+        // 현재는 통계 미구현
+    }
 }

--- a/src/main/java/com/bready/server/trigger/controller/TriggerController.java
+++ b/src/main/java/com/bready/server/trigger/controller/TriggerController.java
@@ -1,6 +1,18 @@
 package com.bready.server.trigger.controller;
 
+import com.bready.server.global.response.CommonResponse;
+import com.bready.server.trigger.dto.TriggerCreateRequest;
+import com.bready.server.trigger.dto.TriggerCreateResponse;
+import com.bready.server.trigger.service.TriggerService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -8,4 +20,42 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/v1/triggers")
 @RequiredArgsConstructor
 public class TriggerController {
+
+    private final TriggerService triggerService;
+
+    @PostMapping
+    @Operation(
+            summary = "트리거 발생",
+            description = "사용자가 특정 플랜/카테고리에서 상황 발생을 선언합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "트리거 발생 성공",
+                    content = @Content(
+                            schema = @Schema(implementation = CommonResponse.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "존재하지 않는 플랜 또는 카테고리",
+                    content = @Content(
+                            schema = @Schema(implementation = CommonResponse.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "403",
+                    description = "트리거 발생 권한 없음 (플랜 소유자 아님)",
+                    content = @Content(
+                            schema = @Schema(implementation = CommonResponse.class)
+                    )
+            )
+    })
+    public CommonResponse<TriggerCreateResponse> createTrigger(
+            @RequestBody @Valid TriggerCreateRequest request
+    ) {
+        return CommonResponse.success(
+                triggerService.createTrigger(request)
+        );
+    }
 }

--- a/src/main/java/com/bready/server/trigger/domain/Trigger.java
+++ b/src/main/java/com/bready/server/trigger/domain/Trigger.java
@@ -1,8 +1,8 @@
 package com.bready.server.trigger.domain;
 
 import com.bready.server.global.entity.BaseEntity;
+import com.bready.server.plan.domain.Plan;
 import com.bready.server.plan.domain.PlanCategory;
-import com.bready.server.user.domain.User;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -19,21 +19,35 @@ public class Trigger extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    // 어떤 플랜에서 발생한 트리거인지
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "plan_id", nullable = false)
+    private Plan plan;
+
     // 발생한 카테고리
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "category_id")
+    @JoinColumn(name = "category_id", nullable = false)
     private PlanCategory category;
 
-    // 트리거를 발생시킨 사용자
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id")
-    private User user;
-
     // 트리거 유형
+    @Enumerated(EnumType.STRING)
     @Column(name = "trigger_type", nullable = false)
-    private String triggerType;
+    private TriggerType triggerType;
 
     // 발생 시각
     @Column(name = "occurred_at", nullable = false)
     private LocalDateTime occurredAt;
+
+    public static Trigger create(
+            Plan plan,
+            PlanCategory category,
+            TriggerType triggerType
+    ) {
+        Trigger trigger = new Trigger();
+        trigger.plan = plan;
+        trigger.category = category;
+        trigger.triggerType = triggerType;
+        trigger.occurredAt = LocalDateTime.now();
+        return trigger;
+    }
 }

--- a/src/main/java/com/bready/server/trigger/domain/TriggerType.java
+++ b/src/main/java/com/bready/server/trigger/domain/TriggerType.java
@@ -1,0 +1,9 @@
+package com.bready.server.trigger.domain;
+
+public enum TriggerType {
+    WEATHER_BAD,        // 날씨 악화
+    WAITING_TOO_LONG,   // 대기시간 과다
+    PLACE_CLOSED,       // 영업 종료
+    FATIGUE,            // 체력 저하
+    DISTANCE_TOO_FAR    // 거리 부담
+}

--- a/src/main/java/com/bready/server/trigger/dto/TriggerCreateRequest.java
+++ b/src/main/java/com/bready/server/trigger/dto/TriggerCreateRequest.java
@@ -2,10 +2,11 @@ package com.bready.server.trigger.dto;
 
 import com.bready.server.trigger.domain.TriggerType;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
 
 public record TriggerCreateRequest(
-        @NotNull Long planId,
-        @NotNull Long categoryId,
+        @NotNull @Positive Long planId,
+        @NotNull @Positive Long categoryId,
         @NotNull TriggerType triggerType
 ) {
 }

--- a/src/main/java/com/bready/server/trigger/dto/TriggerCreateRequest.java
+++ b/src/main/java/com/bready/server/trigger/dto/TriggerCreateRequest.java
@@ -1,0 +1,11 @@
+package com.bready.server.trigger.dto;
+
+import com.bready.server.trigger.domain.TriggerType;
+import jakarta.validation.constraints.NotNull;
+
+public record TriggerCreateRequest(
+        @NotNull Long planId,
+        @NotNull Long categoryId,
+        @NotNull TriggerType triggerType
+) {
+}

--- a/src/main/java/com/bready/server/trigger/dto/TriggerCreateResponse.java
+++ b/src/main/java/com/bready/server/trigger/dto/TriggerCreateResponse.java
@@ -1,0 +1,12 @@
+package com.bready.server.trigger.dto;
+
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Builder
+public record TriggerCreateResponse(
+        Long triggerId,
+        LocalDateTime occurredAt
+) {
+}

--- a/src/main/java/com/bready/server/trigger/exception/TriggerErrorCase.java
+++ b/src/main/java/com/bready/server/trigger/exception/TriggerErrorCase.java
@@ -10,7 +10,9 @@ import org.springframework.http.HttpStatus;
 public enum TriggerErrorCase implements ErrorCase {
 
     TRIGGER_NOT_FOUND(HttpStatus.NOT_FOUND, 7001, "트리거를 찾을 수 없습니다."),
-    TRIGGER_ALREADY_EXECUTED(HttpStatus.BAD_REQUEST, 7002, "이미 실행된 트리거입니다.");
+    TRIGGER_ALREADY_EXECUTED(HttpStatus.BAD_REQUEST, 7002, "이미 실행된 트리거입니다."),
+    PLAN_OR_CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, 4043, "존재하지 않는 플랜 또는 카테고리 입니다."),
+    TRIGGER_FORBIDDEN(HttpStatus.FORBIDDEN, 4033, "트리거를 발생시킬 권한이 없습니다.");
 
     private final HttpStatus httpStatus;
     private final Integer errorCode;

--- a/src/main/java/com/bready/server/trigger/exception/TriggerErrorCase.java
+++ b/src/main/java/com/bready/server/trigger/exception/TriggerErrorCase.java
@@ -11,8 +11,8 @@ public enum TriggerErrorCase implements ErrorCase {
 
     TRIGGER_NOT_FOUND(HttpStatus.NOT_FOUND, 7001, "트리거를 찾을 수 없습니다."),
     TRIGGER_ALREADY_EXECUTED(HttpStatus.BAD_REQUEST, 7002, "이미 실행된 트리거입니다."),
-    PLAN_OR_CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, 4043, "존재하지 않는 플랜 또는 카테고리 입니다."),
-    TRIGGER_FORBIDDEN(HttpStatus.FORBIDDEN, 4033, "트리거를 발생시킬 권한이 없습니다.");
+    PLAN_OR_CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, 7003, "존재하지 않는 플랜 또는 카테고리 입니다."),
+    TRIGGER_FORBIDDEN(HttpStatus.FORBIDDEN, 7004, "트리거를 발생시킬 권한이 없습니다.");
 
     private final HttpStatus httpStatus;
     private final Integer errorCode;

--- a/src/main/java/com/bready/server/trigger/service/TriggerService.java
+++ b/src/main/java/com/bready/server/trigger/service/TriggerService.java
@@ -1,9 +1,53 @@
 package com.bready.server.trigger.service;
 
+import com.bready.server.global.exception.ApplicationException;
+import com.bready.server.plan.domain.Plan;
+import com.bready.server.plan.domain.PlanCategory;
+import com.bready.server.plan.repository.PlanCategoryRepository;
+import com.bready.server.plan.repository.PlanRepository;
+import com.bready.server.trigger.domain.Trigger;
+import com.bready.server.trigger.dto.TriggerCreateRequest;
+import com.bready.server.trigger.dto.TriggerCreateResponse;
+import com.bready.server.trigger.exception.TriggerErrorCase;
+import com.bready.server.trigger.repository.TriggerRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class TriggerService {
+
+    private final PlanRepository planRepository;
+    private final PlanCategoryRepository planCategoryRepository;
+    private final TriggerRepository triggerRepository;
+
+    @Transactional
+    public TriggerCreateResponse createTrigger(TriggerCreateRequest request) {
+
+        Plan plan = planRepository.findById(request.planId())
+                .orElseThrow(() ->
+                        ApplicationException.from(TriggerErrorCase.PLAN_OR_CATEGORY_NOT_FOUND)
+                );
+
+        // TODO: 인증 도입 후 플랜 소유자 검증 로직 추가 필요
+        // if (!category.getPlan().isOwnedBy(currentUserId)) {
+        //     throw ApplicationException.from(TriggerErrorCase.NO_TRIGGER_PERMISSION);
+        // }
+
+        PlanCategory category = planCategoryRepository
+                .findByIdAndPlan_Id(request.categoryId(), request.planId())
+                .orElseThrow(() ->
+                        ApplicationException.from(TriggerErrorCase.PLAN_OR_CATEGORY_NOT_FOUND)
+                );
+
+        Trigger trigger = triggerRepository.save(
+                Trigger.create(plan, category, request.triggerType())
+        );
+
+        return TriggerCreateResponse.builder()
+                .triggerId(trigger.getId())
+                .occurredAt(trigger.getOccurredAt())
+                .build();
+    }
 }

--- a/src/main/java/com/bready/server/trigger/service/TriggerService.java
+++ b/src/main/java/com/bready/server/trigger/service/TriggerService.java
@@ -1,7 +1,6 @@
 package com.bready.server.trigger.service;
 
 import com.bready.server.global.exception.ApplicationException;
-import com.bready.server.plan.domain.Plan;
 import com.bready.server.plan.domain.PlanCategory;
 import com.bready.server.plan.repository.PlanCategoryRepository;
 import com.bready.server.plan.repository.PlanRepository;
@@ -27,7 +26,8 @@ public class TriggerService {
     @Transactional
     public TriggerCreateResponse createTrigger(TriggerCreateRequest request) {
 
-        Plan plan = planRepository.findById(request.planId())
+        PlanCategory category = planCategoryRepository
+                .findByIdAndPlan_Id(request.categoryId(), request.planId())
                 .orElseThrow(() ->
                         ApplicationException.from(TriggerErrorCase.PLAN_OR_CATEGORY_NOT_FOUND)
                 );
@@ -37,14 +37,8 @@ public class TriggerService {
         //     throw ApplicationException.from(TriggerErrorCase.NO_TRIGGER_PERMISSION);
         // }
 
-        PlanCategory category = planCategoryRepository
-                .findByIdAndPlan_Id(request.categoryId(), request.planId())
-                .orElseThrow(() ->
-                        ApplicationException.from(TriggerErrorCase.PLAN_OR_CATEGORY_NOT_FOUND)
-                );
-
         Trigger trigger = triggerRepository.save(
-                Trigger.create(plan, category, request.triggerType())
+                Trigger.create(category.getPlan(), category, request.triggerType())
         );
 
         // 통계 증가 (결정/장소 변경 없음)

--- a/src/main/java/com/bready/server/trigger/service/TriggerService.java
+++ b/src/main/java/com/bready/server/trigger/service/TriggerService.java
@@ -5,6 +5,7 @@ import com.bready.server.plan.domain.Plan;
 import com.bready.server.plan.domain.PlanCategory;
 import com.bready.server.plan.repository.PlanCategoryRepository;
 import com.bready.server.plan.repository.PlanRepository;
+import com.bready.server.stats.service.PlanStatsService;
 import com.bready.server.trigger.domain.Trigger;
 import com.bready.server.trigger.dto.TriggerCreateRequest;
 import com.bready.server.trigger.dto.TriggerCreateResponse;
@@ -21,6 +22,7 @@ public class TriggerService {
     private final PlanRepository planRepository;
     private final PlanCategoryRepository planCategoryRepository;
     private final TriggerRepository triggerRepository;
+    private final PlanStatsService planStatsService;
 
     @Transactional
     public TriggerCreateResponse createTrigger(TriggerCreateRequest request) {
@@ -44,6 +46,9 @@ public class TriggerService {
         Trigger trigger = triggerRepository.save(
                 Trigger.create(plan, category, request.triggerType())
         );
+
+        // 통계 증가 (결정/장소 변경 없음)
+        planStatsService.increaseTriggerCount(category.getPlan().getId());
 
         return TriggerCreateResponse.builder()
                 .triggerId(trigger.getId())


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #27 

## 📝 작업 내용

**특정 플랜/카테고리에서 트리거(상황 발생) 를 생성하는 API를 구현했습니다.**

**트리거는 장소 변경이나 대표 후보 선택을 수행하지 않으며, 상황 발생 기록 및 통계 증가 목적의 API입니다.**

- 트리거 발생 시, 플랜 통계(total_triggers) 증가 로직 연동 (아직 구현 X)
- 인증 미도입 상태이므로 플랜 소유자 검증은 TODO 처리 (추후 연동)

## 🖼️ 스크린샷 (선택)
### 트리거 발생 성공
<img width="1459" height="946" alt="트리거발생성공" src="https://github.com/user-attachments/assets/b16f8415-0302-4430-baab-236ba35d98cc" />


### 트리거 발생 실패 (존재하지 않는 플랜 or 카테고리)
<img width="1469" height="944" alt="트리거발생실패" src="https://github.com/user-attachments/assets/9ff734bd-7160-42c8-9fd3-5494219a35a1" />


## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특히 봐주었으면 하는 부분이 있다면 작성해주세요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 트리거 생성 API 엔드포인트 추가 (요청 유효성 검증 포함)
  * 다양한 트리거 유형 지원: WEATHER_BAD, WAITING_TOO_LONG, PLACE_CLOSED, FATIGUE, DISTANCE_TOO_FAR
  * 플랜별 트리거 통계 기록 기능 추가

* **오류/응답**
  * 플랜 또는 카테고리 미존재 및 권한 부족에 대한 명확한 오류 응답 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->