### PR TITLE
[test] 장소 후보 관련 컨트롤러,서비스 테스트코드 로직 구현

### DIFF
--- a/src/test/java/com/bready/server/global/config/security/TestSecurityConfig.java
+++ b/src/test/java/com/bready/server/global/config/security/TestSecurityConfig.java
@@ -1,0 +1,18 @@
+package com.bready.server.global.config.security;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@TestConfiguration
+public class TestSecurityConfig {
+
+    @Bean
+    SecurityFilterChain testSecurityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(csrf -> csrf.disable())
+                .authorizeHttpRequests(auth -> auth.anyRequest().permitAll());
+        return http.build();
+    }
+}

--- a/src/test/java/com/bready/server/place/controller/PlaceCandidateControllerTest.java
+++ b/src/test/java/com/bready/server/place/controller/PlaceCandidateControllerTest.java
@@ -1,0 +1,144 @@
+package com.bready.server.place.controller;
+
+import com.bready.server.global.config.security.TestSecurityConfig;
+import com.bready.server.global.exception.ApplicationException;
+import com.bready.server.place.dto.PlaceCandidateCreateRequest;
+import com.bready.server.place.dto.PlaceCandidateCreateResponse;
+import com.bready.server.place.dto.PlaceCandidateDeleteResponse;
+import com.bready.server.place.dto.PlaceCandidateRepresentativeResponse;
+import com.bready.server.place.exception.PlaceErrorCase;
+import com.bready.server.place.service.PlaceCandidateService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(PlaceCandidateController.class)
+@Import(TestSecurityConfig.class)
+class PlaceCandidateControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private PlaceCandidateService placeCandidateService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    @DisplayName("장소 후보 등록 성공 → 200 성공")
+    void createCandidate_success() throws Exception {
+
+        PlaceCandidateCreateRequest request =
+                new PlaceCandidateCreateRequest(
+                        1L,
+                        1L,
+                        "kakao-123",
+                        "성수 카페",
+                        "서울 성동구",
+                        BigDecimal.valueOf(37.5),
+                        BigDecimal.valueOf(127.0),
+                        true
+                );
+
+        PlaceCandidateCreateResponse response =
+                PlaceCandidateCreateResponse.builder()
+                        .candidateId(10L)
+                        .createdAt(LocalDateTime.now())
+                        .build();
+
+        given(placeCandidateService.createCandidate(any()))
+                .willReturn(response);
+
+        mockMvc.perform(
+                        post("/api/v1/places/candidates")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request))
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("success"))
+                .andExpect(jsonPath("$.data.candidateId").value(10L));
+    }
+
+    @Test
+    @DisplayName("장소 후보 중복 등록 → 409 실패")
+    void createCandidate_duplicate() throws Exception {
+
+        given(placeCandidateService.createCandidate(any()))
+                .willThrow(ApplicationException.from(
+                        PlaceErrorCase.DUPLICATE_PLACE_CANDIDATE
+                ));
+
+        mockMvc.perform(
+                        post("/api/v1/places/candidates")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content("""
+                        {
+                          "planId": 1,
+                          "categoryId": 1,
+                          "externalId": "kakao-123",
+                          "name": "성수 카페",
+                          "latitude": 37.5,
+                          "longitude": 127.0,
+                          "isIndoor": true
+                        }
+                    """)
+                )
+                .andExpect(status().isConflict());
+    }
+
+    @Test
+    @DisplayName("대표 후보 선택 성공 → 200 성공")
+    void setRepresentative_success() throws Exception {
+
+        PlaceCandidateRepresentativeResponse response =
+                PlaceCandidateRepresentativeResponse.builder()
+                        .categoryId(1L)
+                        .representativeCandidateId(10L)
+                        .changedAt(LocalDateTime.now())
+                        .build();
+
+        given(placeCandidateService.setRepresentative(10L))
+                .willReturn(response);
+
+        mockMvc.perform(
+                        post("/api/v1/places/candidates/10/representative")
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.representativeCandidateId").value(10L));
+    }
+
+    @Test
+    @DisplayName("장소 후보 삭제 성공 → 200 성공")
+    void deleteCandidate_success() throws Exception {
+
+        PlaceCandidateDeleteResponse response =
+                PlaceCandidateDeleteResponse.builder()
+                        .candidateId(10L)
+                        .deletedAt(LocalDateTime.now())
+                        .build();
+
+        given(placeCandidateService.deleteCandidate(10L))
+                .willReturn(response);
+
+        mockMvc.perform(
+                        delete("/api/v1/places/candidates/10")
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.candidateId").value(10L));
+    }
+}

--- a/src/test/java/com/bready/server/place/controller/PlaceCandidateControllerTest.java
+++ b/src/test/java/com/bready/server/place/controller/PlaceCandidateControllerTest.java
@@ -17,8 +17,10 @@ import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
+
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
+
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;

--- a/src/test/java/com/bready/server/place/service/PlaceCandidateServiceTest.java
+++ b/src/test/java/com/bready/server/place/service/PlaceCandidateServiceTest.java
@@ -1,0 +1,199 @@
+package com.bready.server.place.service;
+
+import com.bready.server.global.exception.ApplicationException;
+import com.bready.server.place.domain.Place;
+import com.bready.server.place.domain.PlaceCandidate;
+import com.bready.server.place.dto.PlaceCandidateCreateRequest;
+import com.bready.server.place.exception.PlaceErrorCase;
+import com.bready.server.place.repository.PlaceCandidateRepository;
+import com.bready.server.plan.domain.CategoryState;
+import com.bready.server.plan.domain.PlanCategory;
+import com.bready.server.plan.repository.CategorySelectionLogRepository;
+import com.bready.server.plan.repository.CategoryStateRepository;
+import com.bready.server.plan.repository.PlanCategoryRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+
+@ExtendWith(MockitoExtension.class)
+class PlaceCandidateServiceTest {
+
+    @InjectMocks
+    private PlaceCandidateService placeCandidateService;
+
+    @Mock
+    private PlanCategoryRepository planCategoryRepository;
+
+    @Mock
+    private PlaceCandidateRepository placeCandidateRepository;
+
+    @Mock
+    private PlacePersistenceService placePersistenceService;
+
+    @Mock
+    private CategoryStateRepository categoryStateRepository;
+
+    @Mock
+    private CategorySelectionLogRepository categorySelectionLogRepository;
+
+    @Test
+    @DisplayName("장소 후보 등록 성공")
+    void createCandidate_success() {
+        PlaceCandidateCreateRequest request =
+                new PlaceCandidateCreateRequest(
+                        1L,
+                        10L,
+                        "kakao-123",
+                        "성수 카페",
+                        "서울 성동구",
+                        BigDecimal.valueOf(37.5),
+                        BigDecimal.valueOf(127.0),
+                        true
+                );
+
+        PlanCategory category = mock(PlanCategory.class);
+        Place place = mock(Place.class);
+
+        PlaceCandidate savedCandidate = mock(PlaceCandidate.class);
+        when(savedCandidate.getId()).thenReturn(100L);
+        when(savedCandidate.getCreatedAt()).thenReturn(LocalDateTime.now());
+
+        when(planCategoryRepository.findByIdAndPlan_Id(10L, 1L))
+                .thenReturn(Optional.of(category));
+
+        when(placePersistenceService.getOrCreate(request))
+                .thenReturn(place);
+
+        when(placeCandidateRepository.saveAndFlush(any()))
+                .thenReturn(savedCandidate);
+
+        var response = placeCandidateService.createCandidate(request);
+
+        assertThat(response.candidateId()).isEqualTo(100L);
+        verify(placeCandidateRepository).saveAndFlush(any());
+    }
+
+    @Test
+    @DisplayName("장소 후보 중복 등록 → DUPLICATE_PLACE_CANDIDATE (실패)")
+    void createCandidate_duplicate() {
+        PlaceCandidateCreateRequest request =
+                new PlaceCandidateCreateRequest(
+                        1L,
+                        10L,
+                        "kakao-123",
+                        "성수 카페",
+                        "서울 성동구",
+                        BigDecimal.valueOf(37.5),
+                        BigDecimal.valueOf(127.0),
+                        true
+                );
+
+        PlanCategory category = mock(PlanCategory.class);
+        Place place = mock(Place.class);
+
+        when(planCategoryRepository.findByIdAndPlan_Id(10L, 1L))
+                .thenReturn(Optional.of(category));
+
+        when(placePersistenceService.getOrCreate(request))
+                .thenReturn(place);
+
+        when(placeCandidateRepository.saveAndFlush(any()))
+                .thenThrow(DataIntegrityViolationException.class);
+
+        assertThatThrownBy(() ->
+                placeCandidateService.createCandidate(request)
+        )
+                .isInstanceOf(ApplicationException.class)
+                .extracting("errorCase")
+                .isEqualTo(PlaceErrorCase.DUPLICATE_PLACE_CANDIDATE);
+    }
+
+    @Test
+    @DisplayName("대표 장소 후보 최초 선택 성공")
+    void setRepresentative_firstTime() {
+        Long candidateId = 100L;
+
+        PlanCategory category = mock(PlanCategory.class);
+        when(category.getId()).thenReturn(10L);
+
+        PlaceCandidate candidate = mock(PlaceCandidate.class);
+        when(candidate.getCategory()).thenReturn(category);
+
+        when(placeCandidateRepository.findByIdWithCategoryAndPlace(candidateId))
+                .thenReturn(Optional.of(candidate));
+
+        when(categoryStateRepository.findByCategory_IdForUpdate(10L))
+                .thenReturn(Optional.empty());
+
+        var response = placeCandidateService.setRepresentative(candidateId);
+
+        assertThat(response.representativeCandidateId()).isEqualTo(candidateId);
+        verify(categoryStateRepository).save(any());
+        verify(categorySelectionLogRepository).save(any());
+    }
+
+    @Test
+    @DisplayName("이미 대표 후보 → 예외 (실패)")
+    void setRepresentative_alreadyRepresentative() {
+        Long candidateId = 100L;
+
+        PlanCategory category = mock(PlanCategory.class);
+        when(category.getId()).thenReturn(10L);
+
+        PlaceCandidate candidate = mock(PlaceCandidate.class);
+        when(candidate.getCategory()).thenReturn(category);
+
+        CategoryState state = mock(CategoryState.class);
+        when(state.isRepresentative(candidateId)).thenReturn(true);
+
+        when(placeCandidateRepository.findByIdWithCategoryAndPlace(candidateId))
+                .thenReturn(Optional.of(candidate));
+
+        when(categoryStateRepository.findByCategory_IdForUpdate(10L))
+                .thenReturn(Optional.of(state));
+
+        assertThatThrownBy(() ->
+                placeCandidateService.setRepresentative(candidateId)
+        )
+                .isInstanceOf(ApplicationException.class)
+                .extracting("errorCase")
+                .isEqualTo(PlaceErrorCase.ALREADY_REPRESENTATIVE_CANDIDATE);
+    }
+
+    @Test
+    @DisplayName("장소 후보 삭제 성공")
+    void deleteCandidate_success() {
+        Long candidateId = 100L;
+
+        PlanCategory category = mock(PlanCategory.class);
+        when(category.getId()).thenReturn(10L);
+
+        PlaceCandidate candidate = mock(PlaceCandidate.class);
+        when(candidate.getCategory()).thenReturn(category);
+
+        when(placeCandidateRepository.findByIdWithCategory(candidateId))
+                .thenReturn(Optional.of(candidate));
+
+        when(categoryStateRepository.findByCategory_IdForUpdate(10L))
+                .thenReturn(Optional.empty());
+
+        var response = placeCandidateService.deleteCandidate(candidateId);
+
+        assertThat(response.candidateId()).isEqualTo(candidateId);
+        verify(candidate).softDelete();
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #29 

## 📝 작업 내용

> 장소 후보 API (장소 후보 등록, 대표 후보 선택, 장소 후보 삭제) 에 관련한 컨트롤러,서비스 테스트코드 구현했습니다.
> 모든 테스트 통과 확인 완료

## 🖼️ 스크린샷 (선택)

>

## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특히 봐주었으면 하는 부분이 있다면 작성해주세요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Tests**
  * 장소 후보 생성, 수정, 삭제 기능에 대한 API 엔드포인트 통합 테스트 추가
  * 중복 후보 처리 및 예외 상황에 대한 테스트 추가
  * 장소 후보 서비스의 비즈니스 로직 단위 테스트 추가
  * 테스트 환경용 보안 설정 구성 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->