### PR TITLE
[feat] 로그인 / 사용자 조회 / 토큰 재발급 API 구현

### DIFF
--- a/src/main/java/com/bready/server/auth/controller/AuthController.java
+++ b/src/main/java/com/bready/server/auth/controller/AuthController.java
@@ -1,6 +1,7 @@
 package com.bready.server.auth.controller;
 
 import com.bready.server.auth.dto.LoginRequest;
+import com.bready.server.auth.dto.RefreshRequest;
 import com.bready.server.auth.dto.SignupRequest;
 import com.bready.server.auth.dto.SignupResponse;
 import com.bready.server.auth.dto.TokenResponse;
@@ -21,7 +22,9 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 public class AuthController {
 
+
     private final AuthService authService;
+
 
     @PostMapping("/signup")
     @ResponseStatus(HttpStatus.CREATED)
@@ -44,6 +47,7 @@ public class AuthController {
         return CommonResponse.success(authService.signup(request));
     }
 
+
     @PostMapping("/login")
     @ResponseStatus(HttpStatus.OK)
     @Operation(
@@ -55,12 +59,32 @@ public class AuthController {
                     content = @Content(schema = @Schema(implementation = CommonResponse.class))),
             @ApiResponse(responseCode = "400", description = "요청 값 오류 (누락 또는 형식 오류)",
                     content = @Content(schema = @Schema(implementation = CommonResponse.class))),
-            @ApiResponse(responseCode = "401", description = "로그인 실패 (이메일 또는 비밀번호 불일치",
+            @ApiResponse(responseCode = "401", description = "로그인 실패 (이메일 또는 비밀번호 불일치)",
                     content = @Content(schema = @Schema(implementation = CommonResponse.class)))
     })
     public CommonResponse<TokenResponse> login(
             @Valid @RequestBody LoginRequest request
     ) {
         return CommonResponse.success(authService.login(request));
+    }
+
+    @PostMapping("/refresh")
+    @ResponseStatus(HttpStatus.OK)
+    @Operation(
+            summary = "토큰 재발급",
+            description = "refreshToken으로 access/refresh 토큰을 재발급"
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "재발급 성공",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "400", description = "필수 값 누락",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "401", description = "유효하지 않은 토큰/만료된 토큰/서버와 불일치",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class)))
+    })
+    public CommonResponse<TokenResponse> refresh(
+            @Valid @RequestBody RefreshRequest request
+    ) {
+        return CommonResponse.success(authService.refresh(request));
     }
 }

--- a/src/main/java/com/bready/server/auth/controller/AuthController.java
+++ b/src/main/java/com/bready/server/auth/controller/AuthController.java
@@ -1,7 +1,9 @@
 package com.bready.server.auth.controller;
 
+import com.bready.server.auth.dto.LoginRequest;
 import com.bready.server.auth.dto.SignupRequest;
 import com.bready.server.auth.dto.SignupResponse;
+import com.bready.server.auth.dto.TokenResponse;
 import com.bready.server.auth.service.AuthService;
 import com.bready.server.global.response.CommonResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -12,7 +14,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -29,19 +30,11 @@ public class AuthController {
             description = "이메일/비밀번호로 회원가입을 진행하고 사용자 기본 정보를 반환합니다."
     )
     @ApiResponses({
-            @ApiResponse(
-                    responseCode = "201",
-                    description = "회원가입 성공",
-                    content = @Content(schema = @Schema(implementation = CommonResponse.class))
-            ),
-            @ApiResponse(
-                    responseCode = "400",
-                    description = "요청 값 오류 (닉네임/이메일/비밀번호 정책 위반)",
-                    content = @Content(schema = @Schema(implementation = CommonResponse.class))
-            ),
-            @ApiResponse(
-                    responseCode = "409",
-                    description = "이메일 중복",
+            @ApiResponse(responseCode = "201", description = "회원가입 성공",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "400", description = "요청 값 오류 (닉네임/이메일/비밀번호 정책 위반)",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "409", description = "이메일 중복",
                     content = @Content(schema = @Schema(implementation = CommonResponse.class))
             )
     })
@@ -49,5 +42,25 @@ public class AuthController {
             @Valid @RequestBody SignupRequest request
     ) {
         return CommonResponse.success(authService.signup(request));
+    }
+
+    @PostMapping("/login")
+    @ResponseStatus(HttpStatus.OK)
+    @Operation(
+            summary = "로그인",
+            description = "이메일/비밀번호로 로그인, access/refresh 토큰 발급"
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "로그인 성공",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "400", description = "요청 값 오류 (누락 또는 형식 오류)",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "401", description = "로그인 실패 (이메일 또는 비밀번호 불일치",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class)))
+    })
+    public CommonResponse<TokenResponse> login(
+            @Valid @RequestBody LoginRequest request
+    ) {
+        return CommonResponse.success(authService.login(request));
     }
 }

--- a/src/main/java/com/bready/server/auth/dto/LoginRequest.java
+++ b/src/main/java/com/bready/server/auth/dto/LoginRequest.java
@@ -3,12 +3,14 @@ package com.bready.server.auth.dto;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
 public class LoginRequest {
 
     @NotBlank(message = "이메일을 입력해주세요.")
-    @Email(message = "이메일을 입력해주세요.")
+    @Email(message = "이메일 형식이 올바르지 않습니다.")
     private String email;
 
     @NotBlank(message = "비밀번호를 입력해주세요.")

--- a/src/main/java/com/bready/server/auth/dto/RefreshRequest.java
+++ b/src/main/java/com/bready/server/auth/dto/RefreshRequest.java
@@ -1,0 +1,14 @@
+package com.bready.server.auth.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class RefreshRequest {
+
+    @NotBlank(message = "필수 입력값이 누락되었습니다.")
+    private String refreshToken;
+
+}

--- a/src/main/java/com/bready/server/auth/exception/AuthErrorCase.java
+++ b/src/main/java/com/bready/server/auth/exception/AuthErrorCase.java
@@ -9,10 +9,19 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum AuthErrorCase implements ErrorCase {
 
+    // 토큰 관련
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, 1001, "유효하지 않은 토큰입니다."),
     EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, 1002, "토큰이 만료되었습니다."),
+
+    // 권한
     UNAUTHORIZED(HttpStatus.FORBIDDEN, 1003, "접근 권한이 없습니다."),
-    INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, 4011, "이메일 또는 비밀번호가 올바르지 않습니다.");
+
+    // 로그인
+    INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, 4011, "이메일 또는 비밀번호가 올바르지 않습니다."),
+
+    // refresh 전용
+    REFRESH_TOKEN_INVALID(HttpStatus.UNAUTHORIZED, 4012, "리프레시 토큰이 유효하지 않습니다.");
+
 
     private final HttpStatus httpStatus;
     private final Integer errorCode;

--- a/src/main/java/com/bready/server/auth/exception/AuthErrorCase.java
+++ b/src/main/java/com/bready/server/auth/exception/AuthErrorCase.java
@@ -11,7 +11,8 @@ public enum AuthErrorCase implements ErrorCase {
 
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, 1001, "유효하지 않은 토큰입니다."),
     EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, 1002, "토큰이 만료되었습니다."),
-    UNAUTHORIZED(HttpStatus.FORBIDDEN, 1003, "접근 권한이 없습니다.");
+    UNAUTHORIZED(HttpStatus.FORBIDDEN, 1003, "접근 권한이 없습니다."),
+    INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, 4011, "이메일 또는 비밀번호가 올바르지 않습니다.");
 
     private final HttpStatus httpStatus;
     private final Integer errorCode;

--- a/src/main/java/com/bready/server/auth/service/AuthService.java
+++ b/src/main/java/com/bready/server/auth/service/AuthService.java
@@ -1,10 +1,7 @@
 package com.bready.server.auth.service;
 
 import com.bready.server.auth.domain.RefreshToken;
-import com.bready.server.auth.dto.LoginRequest;
-import com.bready.server.auth.dto.SignupRequest;
-import com.bready.server.auth.dto.SignupResponse;
-import com.bready.server.auth.dto.TokenResponse;
+import com.bready.server.auth.dto.*;
 import com.bready.server.auth.exception.AuthErrorCase;
 import com.bready.server.auth.repository.RefreshTokenRepository;
 import com.bready.server.global.config.security.jwt.JwtTokenProvider;
@@ -54,7 +51,7 @@ public class AuthService {
                     UserProfile.create(user, request.getNickname())
             );
 
-            // 4. 응답 구성
+            // 4) 응답 구성
             String createdAt = user.getCreatedAt() == null
                     ? null
                     : user.getCreatedAt()
@@ -97,6 +94,43 @@ public class AuthService {
         return TokenResponse.builder()
                 .accessToken(accessToken)
                 .refreshToken(refreshToken)
+                .build();
+    }
+
+    @Transactional
+    public TokenResponse refresh(RefreshRequest request) {
+
+        // 1) refresh 토큰 검증
+        jwtTokenProvider.validateRefreshToken(request.getRefreshToken());
+
+        // 2) refresh 토큰에서 userId 추출
+        Long userId = jwtTokenProvider.getUserId(request.getRefreshToken());
+
+        // 3) Redis 에 저장된 refresh 토큰 조회
+        RefreshToken saved = refreshTokenRepository.findById(String.valueOf(userId))
+                .orElseThrow(() -> new ApplicationException(AuthErrorCase.REFRESH_TOKEN_INVALID));
+
+        // 4) 토큰 일치 여부 확인
+        if (!saved.getToken().equals(request.getRefreshToken())) {
+            throw new ApplicationException(AuthErrorCase.REFRESH_TOKEN_INVALID);
+        }
+
+        // 5) 새 토큰 발급
+        String newAccessToken = jwtTokenProvider.generateAccessToken(userId);
+        String newRefreshToken = jwtTokenProvider.generateRefreshToken(userId);
+
+        // 6) Redis refresh 토큰 갱신
+        refreshTokenRepository.save(
+                RefreshToken.builder()
+                        .key(String.valueOf(userId))
+                        .token(newRefreshToken)
+                        .userId(userId)
+                        .build()
+        );
+
+        return TokenResponse.builder()
+                .accessToken(newAccessToken)
+                .refreshToken(newRefreshToken)
                 .build();
     }
 }

--- a/src/main/java/com/bready/server/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/bready/server/global/config/security/SecurityConfig.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -40,6 +41,13 @@ public class SecurityConfig {
                 .sessionManagement(session ->
                         session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 )
+
+                .exceptionHandling(ex -> ex
+                        .authenticationEntryPoint((request, response, authException) ->
+                                response.sendError(HttpStatus.UNAUTHORIZED.value(), "Unauthorized")
+                        )
+                )
+
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(
                                 "/swagger-ui/**",
@@ -49,6 +57,7 @@ public class SecurityConfig {
                         .requestMatchers("/actuator/health", "/actuator/info").permitAll()
                         .requestMatchers("/api/v1/auth/**").permitAll()
                         .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
+
                         // TODO: 로그인,회원가입 API 구현 후 .anyRequest().authenticated() 로 변경
                         .anyRequest().permitAll()
                 )

--- a/src/main/java/com/bready/server/global/config/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/bready/server/global/config/security/jwt/JwtTokenProvider.java
@@ -91,12 +91,12 @@ public class JwtTokenProvider {
                     .getBody();
 
             if (!"refresh".equals(claims.get("typ"))) {
-                throw new ApplicationException(AuthErrorCase.INVALID_TOKEN);
+                throw new ApplicationException(AuthErrorCase.REFRESH_TOKEN_INVALID);
             }
         } catch (ExpiredJwtException e) {
             throw new ApplicationException(AuthErrorCase.EXPIRED_TOKEN);
         } catch (JwtException | IllegalArgumentException e) {
-            throw new ApplicationException(AuthErrorCase.INVALID_TOKEN);
+            throw new ApplicationException(AuthErrorCase.REFRESH_TOKEN_INVALID);
         }
     }
 

--- a/src/main/java/com/bready/server/global/config/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/bready/server/global/config/security/jwt/JwtTokenProvider.java
@@ -1,9 +1,8 @@
 package com.bready.server.global.config.security.jwt;
 
-import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.JwtException;
-import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.SignatureAlgorithm;
+import com.bready.server.auth.exception.AuthErrorCase;
+import com.bready.server.global.exception.ApplicationException;
+import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -80,6 +79,24 @@ public class JwtTokenProvider {
             return "access".equals(claims.get("typ"));
         } catch (JwtException | IllegalArgumentException e) {
             return false;
+        }
+    }
+
+    public void validateRefreshToken(String token) {
+        try {
+            Claims claims = Jwts.parserBuilder()
+                    .setSigningKey(signingKey)
+                    .build()
+                    .parseClaimsJws(token)
+                    .getBody();
+
+            if (!"refresh".equals(claims.get("typ"))) {
+                throw new ApplicationException(AuthErrorCase.INVALID_TOKEN);
+            }
+        } catch (ExpiredJwtException e) {
+            throw new ApplicationException(AuthErrorCase.EXPIRED_TOKEN);
+        } catch (JwtException | IllegalArgumentException e) {
+            throw new ApplicationException(AuthErrorCase.INVALID_TOKEN);
         }
     }
 

--- a/src/main/java/com/bready/server/user/controller/UserController.java
+++ b/src/main/java/com/bready/server/user/controller/UserController.java
@@ -2,8 +2,6 @@ package com.bready.server.user.controller;
 
 import com.bready.server.global.exception.ApplicationException;
 import com.bready.server.global.response.CommonResponse;
-import com.bready.server.user.domain.User;
-import com.bready.server.user.domain.UserProfile;
 import com.bready.server.user.dto.UserProfileDto;
 import com.bready.server.user.exception.UserErrorCase;
 import com.bready.server.user.service.UserService;
@@ -18,9 +16,6 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.time.ZoneOffset;
-import java.time.format.DateTimeFormatter;
 
 @RestController
 @RequestMapping("/api/v1/users")
@@ -46,26 +41,6 @@ public class UserController {
             throw new ApplicationException(UserErrorCase.AUTH_REQUIRED);
         }
 
-        User user = userService.getMe(userId);
-
-        // userProfile 은 join 으로 함께 로딩
-        UserProfile profile = user.getUserProfile();
-
-        String joinedAt = user.getCreatedAt() == null
-                ? null
-                : user.getCreatedAt()
-                .atOffset(ZoneOffset.UTC)
-                .format(DateTimeFormatter.ISO_OFFSET_DATE_TIME);
-
-        UserProfileDto response = UserProfileDto.builder()
-                .userId(user.getId())
-                .nickname(profile.getNickname())
-                .email(user.getEmail())
-                .bio(profile.getBio())
-                .profileImageUrl(profile.getProfileImageUrl())
-                .joinedAt(joinedAt)
-                .build();
-
-        return CommonResponse.success(response);
+        return CommonResponse.success(userService.getMyProfile(userId));
     }
 }

--- a/src/main/java/com/bready/server/user/controller/UserController.java
+++ b/src/main/java/com/bready/server/user/controller/UserController.java
@@ -42,11 +42,10 @@ public class UserController {
     public CommonResponse<UserProfileDto> me() {
 
         Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-        if (auth == null || auth.getPrincipal() == null) {
+        if (auth == null || !(auth.getPrincipal() instanceof Long userId)) {
             throw new ApplicationException(UserErrorCase.AUTH_REQUIRED);
         }
 
-        Long userId = (Long) auth.getPrincipal();
         User user = userService.getMe(userId);
 
         // userProfile 은 join 으로 함께 로딩

--- a/src/main/java/com/bready/server/user/controller/UserController.java
+++ b/src/main/java/com/bready/server/user/controller/UserController.java
@@ -1,11 +1,72 @@
 package com.bready.server.user.controller;
 
+import com.bready.server.global.exception.ApplicationException;
+import com.bready.server.global.response.CommonResponse;
+import com.bready.server.user.domain.User;
+import com.bready.server.user.domain.UserProfile;
+import com.bready.server.user.dto.UserProfileDto;
+import com.bready.server.user.exception.UserErrorCase;
+import com.bready.server.user.service.UserService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
 
 @RestController
 @RequestMapping("/api/v1/users")
 @RequiredArgsConstructor
 public class UserController {
+
+    private final UserService userService;
+
+    @GetMapping("/me")
+    @Operation(summary = "내 정보 조회", description = "JWT 인증된 사용자의 기본 프로필 정보 조회")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공",
+                content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "401", description = "인증 필요",
+                content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "404", description = "사용자 없음",
+                content = @Content(schema = @Schema(implementation = CommonResponse.class)))
+    })
+    public CommonResponse<UserProfileDto> me() {
+
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth == null || auth.getPrincipal() == null) {
+            throw new ApplicationException(UserErrorCase.AUTH_REQUIRED);
+        }
+
+        Long userId = (Long) auth.getPrincipal();
+        User user = userService.getMe(userId);
+
+        // userProfile 은 join 으로 함께 로딩
+        UserProfile profile = user.getUserProfile();
+
+        String joinedAt = user.getCreatedAt() == null
+                ? null
+                : user.getCreatedAt()
+                .atOffset(ZoneOffset.UTC)
+                .format(DateTimeFormatter.ISO_OFFSET_DATE_TIME);
+
+        UserProfileDto response = UserProfileDto.builder()
+                .userId(user.getId())
+                .nickname(profile.getNickname())
+                .email(user.getEmail())
+                .bio(profile.getBio())
+                .profileImageUrl(profile.getProfileImageUrl())
+                .joinedAt(joinedAt)
+                .build();
+
+        return CommonResponse.success(response);
+    }
 }

--- a/src/main/java/com/bready/server/user/domain/User.java
+++ b/src/main/java/com/bready/server/user/domain/User.java
@@ -21,6 +21,9 @@ public class User extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private UserStatus status;
 
+    @OneToOne(mappedBy = "user")
+    private UserProfile userProfile;
+
     public static User create(String email, String encodedPassword) {
         User user = new User();
         user.email = email;

--- a/src/main/java/com/bready/server/user/domain/UserProfile.java
+++ b/src/main/java/com/bready/server/user/domain/UserProfile.java
@@ -18,7 +18,7 @@ public class UserProfile {
 
     private String profileImageUrl;
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @OneToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "user_id", nullable = false)
     private User user; // 유저와의 연관관계 설정 (1:1)
 

--- a/src/main/java/com/bready/server/user/dto/UserProfileDto.java
+++ b/src/main/java/com/bready/server/user/dto/UserProfileDto.java
@@ -1,0 +1,13 @@
+package com.bready.server.user.dto;
+
+import lombok.Builder;
+
+@Builder
+public record UserProfileDto(
+        Long userId,
+        String nickname,
+        String email,
+        String bio,
+        String profileImageUrl,
+        String joinedAt
+) {}

--- a/src/main/java/com/bready/server/user/exception/UserErrorCase.java
+++ b/src/main/java/com/bready/server/user/exception/UserErrorCase.java
@@ -9,14 +9,16 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum UserErrorCase implements ErrorCase {
 
-    USER_NOT_FOUND(HttpStatus.NOT_FOUND, 2001, "사용자를 찾을 수 없습니다."),
-
-    // 회원가입 입력 검증 (명세)
+    // 회원가입 입력 검증
     NICKNAME_POLICY_VIOLATION(HttpStatus.BAD_REQUEST, 4001, "닉네임이 정책을 충족하지 않습니다."),
     INVALID_EMAIL_FORMAT(HttpStatus.BAD_REQUEST, 4002, "이메일 형식이 올바르지 않습니다."),
     WEAK_PASSWORD(HttpStatus.BAD_REQUEST, 4003, "비밀번호가 정책을 충족하지 않습니다."),
 
-    // 회원가입 이메일 중복 (명세)
+    // 사용자 조회
+    AUTH_REQUIRED(HttpStatus.UNAUTHORIZED, 4010, "인증이 필요합니다."),
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, 4041, "사용자 정보를 찾을 수 없습니다."),
+
+    // 회원가입 이메일 중복
     DUPLICATED_EMAIL(HttpStatus.CONFLICT, 4091, "이미 사용 중인 이메일입니다.");
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/bready/server/user/repository/UserRepository.java
+++ b/src/main/java/com/bready/server/user/repository/UserRepository.java
@@ -2,6 +2,7 @@ package com.bready.server.user.repository;
 
 import com.bready.server.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
 
@@ -10,4 +11,12 @@ public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByEmail(String email);
 
     Optional<User> findByEmail(String email);
+
+    @Query("""
+        select u from User u
+        join fetch u.userProfile
+        where u.id = :userId
+    """)
+    Optional<User> findByIdWithProfile(Long userId);
+
 }

--- a/src/main/java/com/bready/server/user/service/UserService.java
+++ b/src/main/java/com/bready/server/user/service/UserService.java
@@ -2,12 +2,16 @@ package com.bready.server.user.service;
 
 import com.bready.server.global.exception.ApplicationException;
 import com.bready.server.user.domain.User;
+import com.bready.server.user.domain.UserProfile;
+import com.bready.server.user.dto.UserProfileDto;
 import com.bready.server.user.exception.UserErrorCase;
-import com.bready.server.user.repository.UserProfileRepository;
 import com.bready.server.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
 
 @Service
 @RequiredArgsConstructor
@@ -16,12 +20,30 @@ public class UserService {
 
     private final UserRepository userRepository;
 
-    public User getMe(Long userId) {
+    public UserProfileDto getMyProfile(Long userId) {
         if (userId == null) {
             throw new ApplicationException(UserErrorCase.AUTH_REQUIRED);
         }
 
-        return userRepository.findByIdWithProfile(userId)
+        User user = userRepository.findByIdWithProfile(userId)
                 .orElseThrow(() -> new ApplicationException(UserErrorCase.USER_NOT_FOUND));
+
+        UserProfile profile = user.getUserProfile();
+
+        String joinedAt = user.getCreatedAt() == null
+                ? null
+                : user.getCreatedAt()
+                .atOffset(ZoneOffset.UTC)
+                .format(DateTimeFormatter.ISO_OFFSET_DATE_TIME);
+
+        return UserProfileDto.builder()
+                .userId(user.getId())
+                .nickname(profile.getNickname())
+                .email(user.getEmail())
+                .bio(profile.getBio())
+                .profileImageUrl(profile.getProfileImageUrl())
+                .joinedAt(joinedAt)
+                .build();
     }
 }
+

--- a/src/main/java/com/bready/server/user/service/UserService.java
+++ b/src/main/java/com/bready/server/user/service/UserService.java
@@ -1,9 +1,27 @@
 package com.bready.server.user.service;
 
+import com.bready.server.global.exception.ApplicationException;
+import com.bready.server.user.domain.User;
+import com.bready.server.user.exception.UserErrorCase;
+import com.bready.server.user.repository.UserProfileRepository;
+import com.bready.server.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class UserService {
+
+    private final UserRepository userRepository;
+
+    public User getMe(Long userId) {
+        if (userId == null) {
+            throw new ApplicationException(UserErrorCase.AUTH_REQUIRED);
+        }
+
+        return userRepository.findByIdWithProfile(userId)
+                .orElseThrow(() -> new ApplicationException(UserErrorCase.USER_NOT_FOUND));
+    }
 }

--- a/src/main/java/com/bready/server/user/service/UserService.java
+++ b/src/main/java/com/bready/server/user/service/UserService.java
@@ -29,6 +29,9 @@ public class UserService {
                 .orElseThrow(() -> new ApplicationException(UserErrorCase.USER_NOT_FOUND));
 
         UserProfile profile = user.getUserProfile();
+        if (profile == null) {
+            throw new ApplicationException(UserErrorCase.USER_NOT_FOUND);
+        }
 
         String joinedAt = user.getCreatedAt() == null
                 ? null


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #31 

## 📝 작업 내용

- 로그인 API 구현 및 JWT (access/refresh) 발급
- 사용자 본인 조회 API `/users/me` 인증 적용
- Refresh Token 기반 토큰 재발급 API 구현
- 인증 실패 시 401 응답으로 보안 처리 정리

## 🖼️ 스크린샷 (선택)

### 로그인 성공 (토큰 발급)
<img width="377" height="403" alt="image" src="https://github.com/user-attachments/assets/8635bb1a-f927-48b3-8f42-1ade389862ec" />

### 사용자 본인 조회
<img width="1804" height="457" alt="image" src="https://github.com/user-attachments/assets/185c9af4-b3c3-4196-90d8-b0ebfc2f8b92" />

### 토큰 재발급
<img width="405" height="374" alt="image" src="https://github.com/user-attachments/assets/b8865978-65c3-4f63-8bdb-a663203ea95f" />



## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특히 봐주었으면 하는 부분이 있다면 작성해주세요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 로그인 및 액세스/리프레시 토큰 발급 기능 추가
  * 리프레시 토큰으로 토큰 재발급 기능 추가
  * 인증된 사용자의 프로필 조회 API 추가

* **개선 사항**
  * 인증/토큰 관련 오류 처리 및 상태 코드 정교화
  * 프로필 연관성 및 입력 유효성 검사 강화 (메시지 개선 포함)

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->