### PR TITLE
[feat] 트리거 결정 등록 API 구현

### DIFF
--- a/src/main/java/com/bready/server/trigger/controller/DecisionController.java
+++ b/src/main/java/com/bready/server/trigger/controller/DecisionController.java
@@ -1,0 +1,44 @@
+package com.bready.server.trigger.controller;
+
+import com.bready.server.global.response.CommonResponse;
+import com.bready.server.trigger.dto.DecisionCreateRequest;
+import com.bready.server.trigger.dto.DecisionCreateResponse;
+import com.bready.server.trigger.service.DecisionService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/triggers")
+@RequiredArgsConstructor
+public class DecisionController {
+
+    private final DecisionService decisionService;
+
+    @PostMapping("/{triggerId}/decision")
+    @Operation(
+            summary = "트리거 결정 등록",
+            description = "발생한 트리거에 대해 유지(KEEP) 또는 전환(SWITCH)을 결정합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "결정 성공",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 트리거",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "409", description = "이미 결정된 트리거",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class)))
+    })
+    public CommonResponse<DecisionCreateResponse> createDecision(
+            @PathVariable Long triggerId,
+            @RequestBody @Valid DecisionCreateRequest request
+    ) {
+        return CommonResponse.success(
+                decisionService.createDecision(triggerId, request)
+        );
+    }
+}

--- a/src/main/java/com/bready/server/trigger/domain/Decision.java
+++ b/src/main/java/com/bready/server/trigger/domain/Decision.java
@@ -27,8 +27,8 @@ public class Decision extends BaseEntity {
     private Long id;
 
     // 어떤 트리거에 대한 결정인가
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "trigger_id", nullable = false, unique = true)
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "trigger_id", nullable = false)
     private Trigger trigger;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/bready/server/trigger/domain/Decision.java
+++ b/src/main/java/com/bready/server/trigger/domain/Decision.java
@@ -2,15 +2,24 @@ package com.bready.server.trigger.domain;
 
 import com.bready.server.global.entity.BaseEntity;
 import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
 @Getter
-@NoArgsConstructor
 @Entity
-@Table(name = "decisions")
+@Table(
+        name = "decisions",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_decision_trigger",
+                        columnNames = "trigger_id"
+                )
+        }
+)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Decision extends BaseEntity {
 
     @Id
@@ -19,14 +28,28 @@ public class Decision extends BaseEntity {
 
     // 어떤 트리거에 대한 결정인가
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "trigger_id", nullable = false)
+    @JoinColumn(name = "trigger_id", nullable = false, unique = true)
     private Trigger trigger;
 
-    // 결정 유형 (KEEP / SWITCH)
+    @Enumerated(EnumType.STRING)
     @Column(name = "decision_type", nullable = false)
-    private String decisionType;
+    private DecisionType decisionType; // 결정 관련 타입
 
-    // 결정 시각
     @Column(name = "decided_at", nullable = false)
     private LocalDateTime decidedAt;
+
+    public static Decision create(
+            Trigger trigger,
+            DecisionType decisionType
+    ) {
+        Decision decision = new Decision();
+        decision.trigger = trigger;
+        decision.decisionType = decisionType;
+        decision.decidedAt = LocalDateTime.now();
+        return decision;
+    }
+
+    public boolean isSwitch() {
+        return decisionType == DecisionType.SWITCH;
+    }
 }

--- a/src/main/java/com/bready/server/trigger/domain/DecisionType.java
+++ b/src/main/java/com/bready/server/trigger/domain/DecisionType.java
@@ -1,0 +1,6 @@
+package com.bready.server.trigger.domain;
+
+public enum DecisionType {
+    KEEP,
+    SWITCH
+}

--- a/src/main/java/com/bready/server/trigger/dto/DecisionCreateRequest.java
+++ b/src/main/java/com/bready/server/trigger/dto/DecisionCreateRequest.java
@@ -1,0 +1,9 @@
+package com.bready.server.trigger.dto;
+
+import com.bready.server.trigger.domain.DecisionType;
+import jakarta.validation.constraints.NotNull;
+
+public record DecisionCreateRequest(
+        @NotNull DecisionType decisionType
+) {
+}

--- a/src/main/java/com/bready/server/trigger/dto/DecisionCreateResponse.java
+++ b/src/main/java/com/bready/server/trigger/dto/DecisionCreateResponse.java
@@ -1,0 +1,13 @@
+package com.bready.server.trigger.dto;
+
+import lombok.Builder;
+import java.time.LocalDateTime;
+
+@Builder
+public record DecisionCreateResponse(
+        Long decisionId,
+        String decisionType,
+        LocalDateTime decidedAt,
+        Boolean needSwitch // SWITCH일 때만 true
+) {
+}

--- a/src/main/java/com/bready/server/trigger/exception/TriggerDecisionErrorCase.java
+++ b/src/main/java/com/bready/server/trigger/exception/TriggerDecisionErrorCase.java
@@ -1,0 +1,31 @@
+package com.bready.server.trigger.exception;
+
+import com.bready.server.global.exception.ErrorCase;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum TriggerDecisionErrorCase implements ErrorCase {
+
+    TRIGGER_NOT_FOUND(HttpStatus.NOT_FOUND, 7101, "존재하지 않는 트리거입니다."),
+    DECISION_ALREADY_MADE(HttpStatus.CONFLICT, 7102, "이미 결정이 완료된 트리거입니다.");
+
+    private final HttpStatus httpStatus;
+    private final Integer errorCode;
+    private final String message;
+
+    @Override
+    public Integer getHttpStatusCode() { return httpStatus.value(); }
+
+    @Override
+    public Integer getErrorCode() {
+        return errorCode;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/com/bready/server/trigger/repository/DecisionRepository.java
+++ b/src/main/java/com/bready/server/trigger/repository/DecisionRepository.java
@@ -3,5 +3,9 @@ package com.bready.server.trigger.repository;
 import com.bready.server.trigger.domain.Decision;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface DecisionRepository extends JpaRepository<Decision, Long> {
+    boolean existsByTrigger_Id(Long triggerId);
+    Optional<Decision> findByTrigger_Id(Long triggerId);
 }

--- a/src/main/java/com/bready/server/trigger/service/DecisionService.java
+++ b/src/main/java/com/bready/server/trigger/service/DecisionService.java
@@ -1,0 +1,49 @@
+package com.bready.server.trigger.service;
+
+import com.bready.server.global.exception.ApplicationException;
+import com.bready.server.trigger.domain.Decision;
+import com.bready.server.trigger.domain.Trigger;
+import com.bready.server.trigger.dto.DecisionCreateRequest;
+import com.bready.server.trigger.dto.DecisionCreateResponse;
+import com.bready.server.trigger.exception.TriggerDecisionErrorCase;
+import com.bready.server.trigger.repository.DecisionRepository;
+import com.bready.server.trigger.repository.TriggerRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class DecisionService {
+
+    private final TriggerRepository triggerRepository;
+    private final DecisionRepository decisionRepository;
+
+    @Transactional
+    public DecisionCreateResponse createDecision(
+            Long triggerId,
+            DecisionCreateRequest request
+    ) {
+        Trigger trigger = triggerRepository.findById(triggerId)
+                .orElseThrow(() ->
+                        ApplicationException.from(TriggerDecisionErrorCase.TRIGGER_NOT_FOUND)
+                );
+
+        // 이미 결정된 트리거인지 확인
+        if (decisionRepository.existsByTrigger_Id(triggerId)) {
+            throw ApplicationException.from(TriggerDecisionErrorCase.DECISION_ALREADY_MADE);
+        }
+
+        Decision decision = decisionRepository.save(
+                Decision.create(trigger, request.decisionType())
+        );
+
+
+        return DecisionCreateResponse.builder()
+                .decisionId(decision.getId())
+                .decisionType(decision.getDecisionType().name())
+                .decidedAt(decision.getDecidedAt())
+                .needSwitch(decision.isSwitch() ? true : null)
+                .build();
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #33 

## 📝 작업 내용

> 트리거가 발생한 후, 사용자가 트리거에 대한 결정을 유지할지, 바꿀지에 대한 선택을 할 수 있도록 관련 API를 구현했습니다.

## 🖼️ 스크린샷 (선택)
### 트리거 결정 등록 성공 (KEEP)
<img width="1487" height="939" alt="트리거결정성공1" src="https://github.com/user-attachments/assets/aedc2bfe-ce9c-4ee5-9ae5-cc39e823cc87" />

### 트리거 결정 등록 성공 (SWITCH)
<img width="1467" height="945" alt="트리거결정성공2" src="https://github.com/user-attachments/assets/e718b8d9-e829-4a18-9498-fa94c07b78a9" />

### 트리거 결정 등록 실패 (이미 등록한 트리거)
<img width="1478" height="943" alt="트리거결정실패" src="https://github.com/user-attachments/assets/a7b1f1ce-8f50-4ce0-9e2b-69d6304362bf" />

## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특히 봐주었으면 하는 부분이 있다면 작성해주세요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 트리거에 대한 결정 생성 API 추가 (결정 유형: KEEP/ SWITCH 선택 가능)
  * 결정 생성 응답에 ID, 유형, 결정 시각 및 전환 필요 여부 포함

* **버그 수정 / 안정성**
  * 중복 결정 방지 및 존재하지 않는 트리거에 대한 명확한 오류 처리 추가
  * 입력 유효성 검증 강화 및 트랜잭션 예외 처리 개선

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->