### PR TITLE
[feat] 장소 전환 확정 API 구현

### DIFF
--- a/src/main/java/com/bready/server/place/repository/PlaceCandidateRepository.java
+++ b/src/main/java/com/bready/server/place/repository/PlaceCandidateRepository.java
@@ -41,4 +41,13 @@ public interface PlaceCandidateRepository extends JpaRepository<PlaceCandidate, 
           and pc.deletedAt is null
     """)
     boolean existsAliveByIdAndCategoryId(Long candidateId, Long categoryId);
+
+    @Query("""
+        select pc
+        from PlaceCandidate pc
+        where pc.id = :candidateId
+          and pc.category.id = :categoryId
+          and pc.deletedAt is null
+    """)
+    Optional<PlaceCandidate> findAliveByIdAndCategoryId(Long candidateId, Long categoryId);
 }

--- a/src/main/java/com/bready/server/place/repository/PlaceCandidateRepository.java
+++ b/src/main/java/com/bready/server/place/repository/PlaceCandidateRepository.java
@@ -23,4 +23,22 @@ public interface PlaceCandidateRepository extends JpaRepository<PlaceCandidate, 
         where pc.id = :candidateId
     """)
     Optional<PlaceCandidate> findByIdWithCategory(Long candidateId);
+
+    @Query("""
+        select pc
+        from PlaceCandidate pc
+        where pc.id = :candidateId
+          and pc.deletedAt is null
+    """)
+    Optional<PlaceCandidate> findAliveById(Long candidateId);
+
+    // 카테고리 일치 + 살아있는 후보 검증
+    @Query("""
+        select (count(pc) > 0)
+        from PlaceCandidate pc
+        where pc.id = :candidateId
+          and pc.category.id = :categoryId
+          and pc.deletedAt is null
+    """)
+    boolean existsAliveByIdAndCategoryId(Long candidateId, Long categoryId);
 }

--- a/src/main/java/com/bready/server/stats/service/PlanStatsService.java
+++ b/src/main/java/com/bready/server/stats/service/PlanStatsService.java
@@ -11,4 +11,8 @@ public class PlanStatsService {
     public void increaseTriggerCount(Long planId) {
         // 현재는 통계 미구현
     }
+
+    public void increaseSwitchCount(Long planId) {
+        // TODO: 통계 테이블 도입 후 구현
+    }
 }

--- a/src/main/java/com/bready/server/trigger/controller/SwitchController.java
+++ b/src/main/java/com/bready/server/trigger/controller/SwitchController.java
@@ -1,0 +1,49 @@
+package com.bready.server.trigger.controller;
+
+import com.bready.server.global.response.CommonResponse;
+import com.bready.server.trigger.dto.DecisionSwitchRequest;
+import com.bready.server.trigger.dto.DecisionSwitchResponse;
+import com.bready.server.trigger.service.SwitchService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Positive;
+import lombok.RequiredArgsConstructor;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/triggers")
+@RequiredArgsConstructor
+@Validated
+public class SwitchController {
+
+    private final SwitchService switchService;
+
+    @PostMapping("/{decisionId}/switch")
+    @Operation(
+            summary = "장소 전환 확정",
+            description = "SWITCH 결정에 대해서만 실제 대표 장소 후보를 변경하고 SwitchLog를 생성합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "전환 성공",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "400", description = "KEEP 결정 전환 시도 / 잘못된 후보",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "404", description = "결정/후보/상태 없음",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "409", description = "이미 전환 완료",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class)))
+    })
+    public CommonResponse<DecisionSwitchResponse> executeSwitch(
+            @PathVariable @Positive Long decisionId,
+            @RequestBody @Valid DecisionSwitchRequest request
+    ) {
+        return CommonResponse.success(
+                switchService.executeSwitch(decisionId, request)
+        );
+    }
+}

--- a/src/main/java/com/bready/server/trigger/domain/Decision.java
+++ b/src/main/java/com/bready/server/trigger/domain/Decision.java
@@ -52,4 +52,8 @@ public class Decision extends BaseEntity {
     public boolean isSwitch() {
         return decisionType == DecisionType.SWITCH;
     }
+
+    public Long getTargetCandidateId() {
+        return trigger.getCandidateId(); // SWITCH 대상 후보 ID
+    }
 }

--- a/src/main/java/com/bready/server/trigger/domain/SwitchLog.java
+++ b/src/main/java/com/bready/server/trigger/domain/SwitchLog.java
@@ -22,7 +22,7 @@ public class SwitchLog extends BaseEntity {
     private Long id;
 
     // 어떤 결정에 의해 발생했는지
-    @ManyToOne(fetch = FetchType.LAZY)
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "decision_id", nullable = false)
     private Decision decision;
 

--- a/src/main/java/com/bready/server/trigger/domain/SwitchLog.java
+++ b/src/main/java/com/bready/server/trigger/domain/SwitchLog.java
@@ -9,7 +9,12 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 @Entity
-@Table(name = "switch_logs")
+@Table(
+        name = "switch_logs",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_switchlog_decision", columnNames = "decision_id")
+        }
+)
 public class SwitchLog extends BaseEntity {
 
     @Id

--- a/src/main/java/com/bready/server/trigger/domain/SwitchLog.java
+++ b/src/main/java/com/bready/server/trigger/domain/SwitchLog.java
@@ -30,4 +30,16 @@ public class SwitchLog extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "to_candidate_id", nullable = false)
     private PlaceCandidate toCandidate;
+
+    public static SwitchLog create(
+            Decision decision,
+            PlaceCandidate from,
+            PlaceCandidate to
+    ) {
+        SwitchLog log = new SwitchLog();
+        log.decision = decision;
+        log.fromCandidate = from;
+        log.toCandidate = to;
+        return log;
+    }
 }

--- a/src/main/java/com/bready/server/trigger/domain/Trigger.java
+++ b/src/main/java/com/bready/server/trigger/domain/Trigger.java
@@ -24,6 +24,10 @@ public class Trigger extends BaseEntity {
     @JoinColumn(name = "plan_id", nullable = false)
     private Plan plan;
 
+    // 트리거 발생 당시 선택된 후보
+    @Column(name = "candidate_id", nullable = false)
+    private Long candidateId;
+
     // 발생한 카테고리
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "category_id", nullable = false)
@@ -38,14 +42,30 @@ public class Trigger extends BaseEntity {
     @Column(name = "occurred_at", nullable = false)
     private LocalDateTime occurredAt;
 
+
     public static Trigger create(
             Plan plan,
             PlanCategory category,
+            Long candidateId,
             TriggerType triggerType
     ) {
+        if (plan == null) {
+            throw new IllegalArgumentException("plan은 필수입니다.");
+        }
+        if (category == null) {
+            throw new IllegalArgumentException("category는 필수입니다.");
+        }
+        if (candidateId == null) {
+            throw new IllegalArgumentException("candidateId는 필수입니다.");
+        }
+        if (triggerType == null) {
+            throw new IllegalArgumentException("triggerType은 필수입니다.");
+        }
+
         Trigger trigger = new Trigger();
         trigger.plan = plan;
         trigger.category = category;
+        trigger.candidateId = candidateId;
         trigger.triggerType = triggerType;
         trigger.occurredAt = LocalDateTime.now();
         return trigger;

--- a/src/main/java/com/bready/server/trigger/dto/DecisionSwitchRequest.java
+++ b/src/main/java/com/bready/server/trigger/dto/DecisionSwitchRequest.java
@@ -1,0 +1,8 @@
+package com.bready.server.trigger.dto;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
+public record DecisionSwitchRequest(
+        @NotNull @Positive Long toCandidateId
+) {}

--- a/src/main/java/com/bready/server/trigger/dto/DecisionSwitchResponse.java
+++ b/src/main/java/com/bready/server/trigger/dto/DecisionSwitchResponse.java
@@ -1,0 +1,13 @@
+package com.bready.server.trigger.dto;
+
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Builder
+public record DecisionSwitchResponse(
+        Long switchLogId,
+        Long fromCandidateId,
+        Long toCandidateId,
+        LocalDateTime switchedAt
+) {}

--- a/src/main/java/com/bready/server/trigger/exception/TriggerErrorCase.java
+++ b/src/main/java/com/bready/server/trigger/exception/TriggerErrorCase.java
@@ -12,7 +12,8 @@ public enum TriggerErrorCase implements ErrorCase {
     TRIGGER_NOT_FOUND(HttpStatus.NOT_FOUND, 7001, "트리거를 찾을 수 없습니다."),
     TRIGGER_ALREADY_EXECUTED(HttpStatus.BAD_REQUEST, 7002, "이미 실행된 트리거입니다."),
     PLAN_OR_CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, 7003, "존재하지 않는 플랜 또는 카테고리 입니다."),
-    TRIGGER_FORBIDDEN(HttpStatus.FORBIDDEN, 7004, "트리거를 발생시킬 권한이 없습니다.");
+    TRIGGER_FORBIDDEN(HttpStatus.FORBIDDEN, 7004, "트리거를 발생시킬 권한이 없습니다."),
+    CATEGORY_STATE_NOT_FOUND(HttpStatus.BAD_REQUEST, 7005, "아직 대표 장소가 선택되지 않은 카테고리입니다.");
 
     private final HttpStatus httpStatus;
     private final Integer errorCode;

--- a/src/main/java/com/bready/server/trigger/exception/TriggerSwitchErrorCase.java
+++ b/src/main/java/com/bready/server/trigger/exception/TriggerSwitchErrorCase.java
@@ -1,0 +1,28 @@
+package com.bready.server.trigger.exception;
+
+import com.bready.server.global.exception.ErrorCase;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum TriggerSwitchErrorCase implements ErrorCase {
+
+    DECISION_NOT_FOUND(HttpStatus.NOT_FOUND, 7201, "존재하지 않는 결정입니다."),
+    KEEP_DECISION_CANNOT_SWITCH(HttpStatus.BAD_REQUEST, 7202, "KEEP 결정에 대해서는 장소 전환이 불가능합니다."),
+    ALREADY_SWITCHED(HttpStatus.CONFLICT, 7203, "이미 전환이 완료된 결정입니다."),
+
+    CATEGORY_STATE_NOT_FOUND(HttpStatus.NOT_FOUND, 7204, "카테고리 상태 정보가 없습니다."),
+    TO_CANDIDATE_NOT_FOUND(HttpStatus.NOT_FOUND, 7205, "전환 대상 장소 후보가 존재하지 않습니다."),
+    TO_CANDIDATE_MISMATCH(HttpStatus.BAD_REQUEST, 7206, "전환 대상 후보가 해당 카테고리에 속하지 않습니다."),
+    SAME_CANDIDATE(HttpStatus.CONFLICT, 7207, "현재 대표 후보와 동일한 후보로는 전환할 수 없습니다.");
+
+    private final HttpStatus httpStatus;
+    private final Integer errorCode;
+    private final String message;
+
+    @Override public Integer getHttpStatusCode() { return httpStatus.value(); }
+    @Override public Integer getErrorCode() { return errorCode; }
+    @Override public String getMessage() { return message; }
+}

--- a/src/main/java/com/bready/server/trigger/exception/TriggerSwitchErrorCase.java
+++ b/src/main/java/com/bready/server/trigger/exception/TriggerSwitchErrorCase.java
@@ -16,7 +16,8 @@ public enum TriggerSwitchErrorCase implements ErrorCase {
     CATEGORY_STATE_NOT_FOUND(HttpStatus.NOT_FOUND, 7204, "카테고리 상태 정보가 없습니다."),
     TO_CANDIDATE_NOT_FOUND(HttpStatus.NOT_FOUND, 7205, "전환 대상 장소 후보가 존재하지 않습니다."),
     TO_CANDIDATE_MISMATCH(HttpStatus.BAD_REQUEST, 7206, "전환 대상 후보가 해당 카테고리에 속하지 않습니다."),
-    SAME_CANDIDATE(HttpStatus.CONFLICT, 7207, "현재 대표 후보와 동일한 후보로는 전환할 수 없습니다.");
+    SAME_CANDIDATE(HttpStatus.CONFLICT, 7207, "현재 대표 후보와 동일한 후보로는 전환할 수 없습니다."),
+    FROM_CANDIDATE_NOT_FOUND(HttpStatus.NOT_FOUND, 7208, "현재 대표 장소 후보가 존재하지 않습니다.");
 
     private final HttpStatus httpStatus;
     private final Integer errorCode;

--- a/src/main/java/com/bready/server/trigger/repository/DecisionRepository.java
+++ b/src/main/java/com/bready/server/trigger/repository/DecisionRepository.java
@@ -2,10 +2,21 @@ package com.bready.server.trigger.repository;
 
 import com.bready.server.trigger.domain.Decision;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
 
 public interface DecisionRepository extends JpaRepository<Decision, Long> {
     boolean existsByTrigger_Id(Long triggerId);
     Optional<Decision> findByTrigger_Id(Long triggerId);
+
+    @Query("""
+        select d
+        from Decision d
+        join fetch d.trigger t
+        join fetch t.category c
+        join fetch t.plan p
+        where d.id = :decisionId
+    """)
+    Optional<Decision> findByIdWithTriggerPlanCategory(Long decisionId);
 }

--- a/src/main/java/com/bready/server/trigger/repository/SwitchLogRepository.java
+++ b/src/main/java/com/bready/server/trigger/repository/SwitchLogRepository.java
@@ -4,4 +4,5 @@ import com.bready.server.trigger.domain.SwitchLog;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface SwitchLogRepository extends JpaRepository<SwitchLog, Long> {
+    boolean existsByDecision_Id(Long decisionId);
 }

--- a/src/main/java/com/bready/server/trigger/service/SwitchService.java
+++ b/src/main/java/com/bready/server/trigger/service/SwitchService.java
@@ -1,0 +1,101 @@
+package com.bready.server.trigger.service;
+
+import com.bready.server.global.exception.ApplicationException;
+import com.bready.server.place.repository.PlaceCandidateRepository;
+import com.bready.server.plan.domain.CategoryState;
+import com.bready.server.plan.domain.PlanCategory;
+import com.bready.server.plan.repository.CategoryStateRepository;
+import com.bready.server.stats.service.PlanStatsService;
+import com.bready.server.trigger.domain.Decision;
+import com.bready.server.trigger.domain.SwitchLog;
+import com.bready.server.trigger.dto.DecisionSwitchRequest;
+import com.bready.server.trigger.dto.DecisionSwitchResponse;
+import com.bready.server.trigger.exception.TriggerSwitchErrorCase;
+import com.bready.server.trigger.repository.DecisionRepository;
+import com.bready.server.trigger.repository.SwitchLogRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class SwitchService {
+
+    private final DecisionRepository decisionRepository;
+    private final SwitchLogRepository switchLogRepository;
+    private final CategoryStateRepository categoryStateRepository;
+    private final PlaceCandidateRepository placeCandidateRepository;
+    private final PlanStatsService planStatsService;
+
+    @Transactional
+    public DecisionSwitchResponse executeSwitch(Long decisionId, DecisionSwitchRequest request) {
+
+        Decision decision = decisionRepository.findByIdWithTriggerPlanCategory(decisionId)
+                .orElseThrow(() -> ApplicationException.from(TriggerSwitchErrorCase.DECISION_NOT_FOUND));
+
+        // SWITCH 결정인지 검증
+        if (!decision.isSwitch()) {
+            throw ApplicationException.from(TriggerSwitchErrorCase.KEEP_DECISION_CANNOT_SWITCH);
+        }
+
+        // 이미 전환된 decision인지 체크
+        if (switchLogRepository.existsByDecision_Id(decisionId)) {
+            throw ApplicationException.from(TriggerSwitchErrorCase.ALREADY_SWITCHED);
+        }
+
+        PlanCategory category = decision.getTrigger().getCategory();
+        Long categoryId = category.getId();
+        Long planId = decision.getTrigger().getPlan().getId();
+
+        Long toCandidateId = request.toCandidateId();
+
+        // 전환 대상 후보가 해당 카테고리 후보인지 검증 (soft delete 포함)
+        if (!placeCandidateRepository.existsAliveByIdAndCategoryId(toCandidateId, categoryId)) {
+            boolean existsAlive = placeCandidateRepository.findAliveById(toCandidateId).isPresent();
+            if (!existsAlive) {
+                throw ApplicationException.from(TriggerSwitchErrorCase.TO_CANDIDATE_NOT_FOUND);
+            }
+            throw ApplicationException.from(TriggerSwitchErrorCase.TO_CANDIDATE_MISMATCH);
+        }
+
+        // CategoryState 락 조회
+        CategoryState state = categoryStateRepository.findByCategory_IdForUpdate(categoryId)
+                .orElseThrow(() -> ApplicationException.from(TriggerSwitchErrorCase.CATEGORY_STATE_NOT_FOUND));
+
+        Long fromCandidateId = state.getCurrentCandidateId();
+
+        // 동일 후보 전환 방지
+        if (fromCandidateId != null && fromCandidateId.equals(toCandidateId)) {
+            throw ApplicationException.from(TriggerSwitchErrorCase.SAME_CANDIDATE);
+        }
+
+        state.changeRepresentative(toCandidateId);
+
+        SwitchLog saved;
+
+        try {
+            saved = switchLogRepository.saveAndFlush(
+                    SwitchLog.create(
+                            decision,
+                            placeCandidateRepository.findAliveById(fromCandidateId)
+                                    .orElseThrow(() -> ApplicationException.from(TriggerSwitchErrorCase.CATEGORY_STATE_NOT_FOUND)),
+                            placeCandidateRepository.findAliveById(toCandidateId)
+                                    .orElseThrow(() -> ApplicationException.from(TriggerSwitchErrorCase.TO_CANDIDATE_NOT_FOUND))
+                    )
+            );
+        } catch (DataIntegrityViolationException e) {
+            throw ApplicationException.from(TriggerSwitchErrorCase.ALREADY_SWITCHED);
+        }
+
+        // 통계 업데이트
+        planStatsService.increaseSwitchCount(planId);
+
+        return DecisionSwitchResponse.builder()
+                .switchLogId(saved.getId())
+                .fromCandidateId(fromCandidateId)
+                .toCandidateId(toCandidateId)
+                .switchedAt(saved.getCreatedAt())
+                .build();
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #35 

## 📝 작업 내용

트리거 결정 이후 실제 장소 전환을 확정하는 API를 구현했습니다.
트리거 → 결정(SWITCH) → 장소 전환에서 최종 상태 변경의 로직입니다.

- decisionType = SWITCH 인 경우만 전환 가능
- KEEP 결정에 대한 전환 요청은 명시적으로 차단

### 현재 트리거 및 결정 관련 동작 흐름 정리
```
1. Trigger 발생 => (POST /api/v1/triggers)
   ↓
2. Decision 등록 (KEEP / SWITCH) => (POST /api/v1/triggers/{triggerId}/decision)   
   ↓
3. 장소 전환 확정 => SWITCH인 경우만 (POST /api/v1/triggers/{decisionId}/switch)
   ↓
4. CategoryState 대표 후보 변경
   ↓
5. SwitchLog 생성
   ↓
6. 통계 업데이트

```

## 🖼️ 스크린샷 (선택)
### 전환 성공
<img width="1486" height="943" alt="전환성공" src="https://github.com/user-attachments/assets/78bf4fa6-ecff-495a-bb42-293ce57600a7" />

### 전환 실패 (트리거 KEEP 일때)
<img width="1478" height="944" alt="전환실패" src="https://github.com/user-attachments/assets/c8e3a0d0-e5bb-4e37-8cf6-c1e790793879" />

## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특히 봐주었으면 하는 부분이 있다면 작성해주세요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 결정 선택지의 대표 후보 전환 기능 및 관련 API 추가
  * 전환 결과 반환(전환 기록 ID, 이전/새 후보, 전환 시각)
  * 통계 집계용 전환 카운트 집계 메서드 추가

* **버그 수정**
  * 후보자·카테고리 검증 강화로 일관성 향상
  * 중복 전환 방지(고유 제약 및 존재 검사) 및 충돌 처리 개선
  * 카테고리 상태 부재 시 명확한 오류 반환

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->