### PR TITLE
[test] 트리거 도메인 관련 컨트롤러,서비스 테스트코드 작성

### DIFF
--- a/src/main/java/com/bready/server/trigger/service/DecisionService.java
+++ b/src/main/java/com/bready/server/trigger/service/DecisionService.java
@@ -46,5 +46,4 @@ public class DecisionService {
                 .needSwitch(decision.isSwitch())
                 .build();
     }
-
 }

--- a/src/test/java/com/bready/server/trigger/controller/DecisionControllerTest.java
+++ b/src/test/java/com/bready/server/trigger/controller/DecisionControllerTest.java
@@ -1,0 +1,67 @@
+package com.bready.server.trigger.controller;
+
+import com.bready.server.global.config.security.TestSecurityConfig;
+import com.bready.server.trigger.dto.DecisionCreateRequest;
+import com.bready.server.trigger.dto.DecisionCreateResponse;
+import com.bready.server.trigger.domain.DecisionType;
+import com.bready.server.trigger.service.DecisionService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(DecisionController.class)
+@Import(TestSecurityConfig.class)
+class DecisionControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private DecisionService decisionService;
+
+    @Test
+    @DisplayName("트리거 결정 등록 성공 (SWITCH) → 200")
+    void createDecision_switch_success() throws Exception {
+
+        DecisionCreateRequest request =
+                new DecisionCreateRequest(DecisionType.SWITCH);
+
+        DecisionCreateResponse response =
+                DecisionCreateResponse.builder()
+                        .decisionId(15L)
+                        .decisionType("SWITCH")
+                        .decidedAt(LocalDateTime.now())
+                        .needSwitch(true)
+                        .build();
+
+        given(decisionService.createDecision(eq(10L), any()))
+                .willReturn(response);
+
+        mockMvc.perform(
+                        post("/api/v1/triggers/10/decision")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request))
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.decisionId").value(15L))
+                .andExpect(jsonPath("$.data.decisionType").value("SWITCH"))
+                .andExpect(jsonPath("$.data.needSwitch").value(true));
+    }
+}

--- a/src/test/java/com/bready/server/trigger/controller/SwitchControllerTest.java
+++ b/src/test/java/com/bready/server/trigger/controller/SwitchControllerTest.java
@@ -1,0 +1,65 @@
+package com.bready.server.trigger.controller;
+
+import com.bready.server.global.config.security.TestSecurityConfig;
+import com.bready.server.trigger.dto.DecisionSwitchRequest;
+import com.bready.server.trigger.dto.DecisionSwitchResponse;
+import com.bready.server.trigger.service.SwitchService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(SwitchController.class)
+@Import(TestSecurityConfig.class)
+class SwitchControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private SwitchService switchService;
+
+    @Test
+    @DisplayName("장소 전환 확정 성공 → 200")
+    void executeSwitch_success() throws Exception {
+
+        DecisionSwitchRequest request =
+                new DecisionSwitchRequest(18L);
+
+        DecisionSwitchResponse response =
+                DecisionSwitchResponse.builder()
+                        .switchLogId(31L)
+                        .fromCandidateId(12L)
+                        .toCandidateId(18L)
+                        .switchedAt(LocalDateTime.now())
+                        .build();
+
+        given(switchService.executeSwitch(eq(20L), any()))
+                .willReturn(response);
+
+        mockMvc.perform(
+                        post("/api/v1/triggers/20/switch")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request))
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.switchLogId").value(31L))
+                .andExpect(jsonPath("$.data.toCandidateId").value(18L));
+    }
+}

--- a/src/test/java/com/bready/server/trigger/controller/SwitchControllerTest.java
+++ b/src/test/java/com/bready/server/trigger/controller/SwitchControllerTest.java
@@ -1,8 +1,10 @@
 package com.bready.server.trigger.controller;
 
 import com.bready.server.global.config.security.TestSecurityConfig;
+import com.bready.server.global.exception.ApplicationException;
 import com.bready.server.trigger.dto.DecisionSwitchRequest;
 import com.bready.server.trigger.dto.DecisionSwitchResponse;
+import com.bready.server.trigger.exception.TriggerSwitchErrorCase;
 import com.bready.server.trigger.service.SwitchService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.DisplayName;
@@ -20,7 +22,8 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(SwitchController.class)
 @Import(TestSecurityConfig.class)
@@ -61,5 +64,22 @@ class SwitchControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.switchLogId").value(31L))
                 .andExpect(jsonPath("$.data.toCandidateId").value(18L));
+    }
+
+    @Test
+    @DisplayName("장소 전환 실패 - KEEP 결정 → 400")
+    void executeSwitch_keepDecision() throws Exception {
+
+        DecisionSwitchRequest request = new DecisionSwitchRequest(18L);
+
+        given(switchService.executeSwitch(eq(20L), any()))
+                .willThrow(ApplicationException.from(TriggerSwitchErrorCase.KEEP_DECISION_CANNOT_SWITCH));
+
+        mockMvc.perform(
+                        post("/api/v1/triggers/20/switch")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request))
+                )
+                .andExpect(status().isBadRequest());
     }
 }

--- a/src/test/java/com/bready/server/trigger/controller/TriggerControllerTest.java
+++ b/src/test/java/com/bready/server/trigger/controller/TriggerControllerTest.java
@@ -1,0 +1,65 @@
+package com.bready.server.trigger.controller;
+
+import com.bready.server.global.config.security.TestSecurityConfig;
+import com.bready.server.trigger.dto.TriggerCreateRequest;
+import com.bready.server.trigger.dto.TriggerCreateResponse;
+import com.bready.server.trigger.domain.TriggerType;
+import com.bready.server.trigger.service.TriggerService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(TriggerController.class)
+@Import(TestSecurityConfig.class)
+class TriggerControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private TriggerService triggerService;
+
+    @Test
+    @DisplayName("트리거 발생 성공 → 200")
+    void createTrigger_success() throws Exception {
+
+        TriggerCreateRequest request = new TriggerCreateRequest(
+                1L,
+                3L,
+                TriggerType.WAITING_TOO_LONG
+        );
+
+        TriggerCreateResponse response = TriggerCreateResponse.builder()
+                .triggerId(10L)
+                .occurredAt(LocalDateTime.now())
+                .build();
+
+        given(triggerService.createTrigger(any()))
+                .willReturn(response);
+
+        mockMvc.perform(
+                        post("/api/v1/triggers")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request))
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("success"))
+                .andExpect(jsonPath("$.data.triggerId").value(10L));
+    }
+}

--- a/src/test/java/com/bready/server/trigger/service/DecisionServiceTest.java
+++ b/src/test/java/com/bready/server/trigger/service/DecisionServiceTest.java
@@ -1,0 +1,89 @@
+package com.bready.server.trigger.service;
+
+import com.bready.server.global.exception.ApplicationException;
+import com.bready.server.trigger.domain.Decision;
+import com.bready.server.trigger.domain.DecisionType;
+import com.bready.server.trigger.domain.Trigger;
+import com.bready.server.trigger.dto.DecisionCreateRequest;
+import com.bready.server.trigger.dto.DecisionCreateResponse;
+import com.bready.server.trigger.repository.DecisionRepository;
+import com.bready.server.trigger.repository.TriggerRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+@ExtendWith(MockitoExtension.class)
+class DecisionServiceTest {
+
+    @InjectMocks
+    private DecisionService decisionService;
+
+    @Mock
+    private TriggerRepository triggerRepository;
+
+    @Mock
+    private DecisionRepository decisionRepository;
+
+    @Test
+    @DisplayName("결정 생성 성공 - SWITCH")
+    void createDecision_success_switch() {
+        Long triggerId = 1L;
+        Trigger trigger = mock(Trigger.class);
+
+        Decision decision = mock(Decision.class);
+        given(decision.getId()).willReturn(10L);
+        given(decision.getDecisionType()).willReturn(DecisionType.SWITCH);
+        given(decision.getDecidedAt()).willReturn(LocalDateTime.now());
+        given(decision.isSwitch()).willReturn(true);
+
+        given(triggerRepository.findById(triggerId)).willReturn(Optional.of(trigger));
+
+        given(decisionRepository.save(any())).willReturn(decision);
+
+        DecisionCreateResponse response =
+                decisionService.createDecision(triggerId, new DecisionCreateRequest(DecisionType.SWITCH));
+
+        assertThat(response.decisionId()).isEqualTo(10L);
+        assertThat(response.decisionType()).isEqualTo("SWITCH");
+        assertThat(response.needSwitch()).isTrue();
+    }
+
+    @Test
+    @DisplayName("결정 생성 실패 - 트리거 없음")
+    void createDecision_triggerNotFound() {
+        given(triggerRepository.findById(1L)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> decisionService.createDecision(1L, new DecisionCreateRequest(DecisionType.KEEP))
+        )
+                .isInstanceOf(ApplicationException.class)
+                .hasMessageContaining("존재하지 않는 트리거");
+    }
+
+    @Test
+    @DisplayName("결정 생성 실패 - 이미 결정됨")
+    void createDecision_alreadyDecided() {
+        Trigger trigger = mock(Trigger.class);
+
+        given(triggerRepository.findById(1L)).willReturn(Optional.of(trigger));
+
+        given(decisionRepository.save(any())).willThrow(DataIntegrityViolationException.class);
+
+        assertThatThrownBy(() -> decisionService.createDecision(1L, new DecisionCreateRequest(DecisionType.KEEP))
+        )
+                .isInstanceOf(ApplicationException.class)
+                .hasMessageContaining("이미 결정이 완료된");
+    }
+}

--- a/src/test/java/com/bready/server/trigger/service/DecisionServiceTest.java
+++ b/src/test/java/com/bready/server/trigger/service/DecisionServiceTest.java
@@ -20,7 +20,7 @@ import java.time.LocalDateTime;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;

--- a/src/test/java/com/bready/server/trigger/service/SwitchServiceTest.java
+++ b/src/test/java/com/bready/server/trigger/service/SwitchServiceTest.java
@@ -4,6 +4,7 @@ import com.bready.server.global.exception.ApplicationException;
 import com.bready.server.place.domain.PlaceCandidate;
 import com.bready.server.place.repository.PlaceCandidateRepository;
 import com.bready.server.plan.domain.CategoryState;
+import com.bready.server.plan.domain.Plan;
 import com.bready.server.plan.domain.PlanCategory;
 import com.bready.server.plan.repository.CategoryStateRepository;
 import com.bready.server.stats.service.PlanStatsService;
@@ -59,6 +60,7 @@ class SwitchServiceTest {
 
         Decision decision = mock(Decision.class);
         Trigger trigger = mock(Trigger.class);
+        Plan plan = mock(Plan.class);
         PlanCategory category = mock(PlanCategory.class);
         CategoryState state = mock(CategoryState.class);
 
@@ -69,8 +71,8 @@ class SwitchServiceTest {
         given(decision.isSwitch()).willReturn(true);
         given(decision.getTrigger()).willReturn(trigger);
         given(trigger.getCategory()).willReturn(category);
-        given(trigger.getPlan().getId()).willReturn(planId);
-        given(category.getId()).willReturn(categoryId);
+        given(trigger.getPlan()).willReturn(plan);
+        given(plan.getId()).willReturn(planId);
 
         given(decisionRepository.findByIdWithTriggerPlanCategory(decisionId))
                 .willReturn(Optional.of(decision));

--- a/src/test/java/com/bready/server/trigger/service/SwitchServiceTest.java
+++ b/src/test/java/com/bready/server/trigger/service/SwitchServiceTest.java
@@ -70,7 +70,10 @@ class SwitchServiceTest {
 
         given(decision.isSwitch()).willReturn(true);
         given(decision.getTrigger()).willReturn(trigger);
+
         given(trigger.getCategory()).willReturn(category);
+        given(category.getId()).willReturn(categoryId);
+
         given(trigger.getPlan()).willReturn(plan);
         given(plan.getId()).willReturn(planId);
 
@@ -138,5 +141,4 @@ class SwitchServiceTest {
                 .isInstanceOf(ApplicationException.class)
                 .hasMessageContaining("이미 전환");
     }
-
 }

--- a/src/test/java/com/bready/server/trigger/service/SwitchServiceTest.java
+++ b/src/test/java/com/bready/server/trigger/service/SwitchServiceTest.java
@@ -1,0 +1,140 @@
+package com.bready.server.trigger.service;
+
+import com.bready.server.global.exception.ApplicationException;
+import com.bready.server.place.domain.PlaceCandidate;
+import com.bready.server.place.repository.PlaceCandidateRepository;
+import com.bready.server.plan.domain.CategoryState;
+import com.bready.server.plan.domain.PlanCategory;
+import com.bready.server.plan.repository.CategoryStateRepository;
+import com.bready.server.stats.service.PlanStatsService;
+import com.bready.server.trigger.domain.Decision;
+import com.bready.server.trigger.domain.SwitchLog;
+import com.bready.server.trigger.domain.Trigger;
+import com.bready.server.trigger.dto.DecisionSwitchRequest;
+import com.bready.server.trigger.dto.DecisionSwitchResponse;
+import com.bready.server.trigger.repository.DecisionRepository;
+import com.bready.server.trigger.repository.SwitchLogRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class SwitchServiceTest {
+
+    @InjectMocks
+    private SwitchService switchService;
+
+    @Mock
+    private DecisionRepository decisionRepository;
+    @Mock
+    private SwitchLogRepository switchLogRepository;
+    @Mock
+    private CategoryStateRepository categoryStateRepository;
+    @Mock
+    private PlaceCandidateRepository placeCandidateRepository;
+    @Mock
+    private PlanStatsService planStatsService;
+
+    @Test
+    @DisplayName("SWITCH 결정 전환 성공")
+    void executeSwitch_success() {
+        Long decisionId = 1L;
+        Long categoryId = 2L;
+        Long planId = 3L;
+        Long fromCandidateId = 10L;
+        Long toCandidateId = 20L;
+
+        Decision decision = mock(Decision.class);
+        Trigger trigger = mock(Trigger.class);
+        PlanCategory category = mock(PlanCategory.class);
+        CategoryState state = mock(CategoryState.class);
+
+        PlaceCandidate fromCandidate = mock(PlaceCandidate.class);
+        PlaceCandidate toCandidate = mock(PlaceCandidate.class);
+        SwitchLog switchLog = mock(SwitchLog.class);
+
+        given(decision.isSwitch()).willReturn(true);
+        given(decision.getTrigger()).willReturn(trigger);
+        given(trigger.getCategory()).willReturn(category);
+        given(trigger.getPlan().getId()).willReturn(planId);
+        given(category.getId()).willReturn(categoryId);
+
+        given(decisionRepository.findByIdWithTriggerPlanCategory(decisionId))
+                .willReturn(Optional.of(decision));
+
+        given(switchLogRepository.existsByDecision_Id(decisionId))
+                .willReturn(false);
+
+        given(placeCandidateRepository.findAliveByIdAndCategoryId(toCandidateId, categoryId))
+                .willReturn(Optional.of(toCandidate));
+
+        given(categoryStateRepository.findByCategory_IdForUpdate(categoryId))
+                .willReturn(Optional.of(state));
+
+        given(state.getCurrentCandidateId())
+                .willReturn(fromCandidateId);
+
+        given(placeCandidateRepository.findAliveById(fromCandidateId))
+                .willReturn(Optional.of(fromCandidate));
+
+        given(switchLogRepository.saveAndFlush(any()))
+                .willReturn(switchLog);
+
+        given(switchLog.getId()).willReturn(100L);
+        given(switchLog.getCreatedAt()).willReturn(LocalDateTime.now());
+
+        DecisionSwitchResponse response = switchService.executeSwitch(decisionId, new DecisionSwitchRequest(toCandidateId));
+
+
+        assertThat(response.fromCandidateId()).isEqualTo(fromCandidateId);
+        assertThat(response.toCandidateId()).isEqualTo(toCandidateId);
+        verify(planStatsService).increaseSwitchCount(planId);
+    }
+
+    @Test
+    @DisplayName("전환 실패 - KEEP 결정")
+    void executeSwitch_keepDecision() {
+        Decision decision = mock(Decision.class);
+        given(decision.isSwitch()).willReturn(false);
+
+        given(decisionRepository.findByIdWithTriggerPlanCategory(1L))
+                .willReturn(Optional.of(decision));
+
+        assertThatThrownBy(() -> switchService.executeSwitch(1L, new DecisionSwitchRequest(20L))
+        )
+                .isInstanceOf(ApplicationException.class)
+                .hasMessageContaining("KEEP 결정");
+    }
+
+    @Test
+    @DisplayName("전환 실패 - 이미 전환됨")
+    void executeSwitch_alreadySwitched() {
+        Decision decision = mock(Decision.class);
+        given(decision.isSwitch()).willReturn(true);
+
+        given(decisionRepository.findByIdWithTriggerPlanCategory(1L))
+                .willReturn(Optional.of(decision));
+
+        given(switchLogRepository.existsByDecision_Id(1L))
+                .willReturn(true);
+
+        assertThatThrownBy(() -> switchService.executeSwitch(1L, new DecisionSwitchRequest(20L))
+        )
+                .isInstanceOf(ApplicationException.class)
+                .hasMessageContaining("이미 전환");
+    }
+
+}

--- a/src/test/java/com/bready/server/trigger/service/TriggerServiceTest.java
+++ b/src/test/java/com/bready/server/trigger/service/TriggerServiceTest.java
@@ -98,4 +98,20 @@ class TriggerServiceTest {
                     assertThat(ae.getErrorCase()).isEqualTo(TriggerErrorCase.CATEGORY_STATE_NOT_FOUND);
                 });
     }
+
+    @Test
+    @DisplayName("트리거 생성 실패 - 플랜/카테고리 없음")
+    void createTrigger_planOrCategoryNotFound() {
+        given(planCategoryRepository.findByIdAndPlan_Id(any(), any()))
+                .willReturn(Optional.empty());
+
+        assertThatThrownBy(() ->
+                triggerService.createTrigger(new TriggerCreateRequest(1L, 999L, TriggerType.WEATHER_BAD))
+        )
+                .isInstanceOf(ApplicationException.class)
+                .satisfies(ex -> {
+                    ApplicationException ae = (ApplicationException) ex;
+                    assertThat(ae.getErrorCase()).isEqualTo(TriggerErrorCase.PLAN_OR_CATEGORY_NOT_FOUND);
+                });
+    }
 }

--- a/src/test/java/com/bready/server/trigger/service/TriggerServiceTest.java
+++ b/src/test/java/com/bready/server/trigger/service/TriggerServiceTest.java
@@ -1,0 +1,101 @@
+package com.bready.server.trigger.service;
+
+import com.bready.server.global.exception.ApplicationException;
+import com.bready.server.plan.domain.CategoryState;
+import com.bready.server.plan.domain.Plan;
+import com.bready.server.plan.domain.PlanCategory;
+import com.bready.server.plan.repository.CategoryStateRepository;
+import com.bready.server.plan.repository.PlanCategoryRepository;
+import com.bready.server.stats.service.PlanStatsService;
+import com.bready.server.trigger.domain.Trigger;
+import com.bready.server.trigger.domain.TriggerType;
+import com.bready.server.trigger.dto.TriggerCreateRequest;
+import com.bready.server.trigger.dto.TriggerCreateResponse;
+import com.bready.server.trigger.exception.TriggerErrorCase;
+import com.bready.server.trigger.repository.TriggerRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class TriggerServiceTest {
+
+    @InjectMocks
+    private TriggerService triggerService;
+
+    @Mock private PlanCategoryRepository planCategoryRepository;
+    @Mock private TriggerRepository triggerRepository;
+    @Mock private PlanStatsService planStatsService;
+    @Mock private CategoryStateRepository categoryStateRepository;
+
+    @Test
+    @DisplayName("트리거 생성 성공")
+    void createTrigger_success() {
+        Long planId = 1L;
+        Long categoryId = 1L;
+        Long currentCandidateId = 10L;
+
+        PlanCategory category = mock(PlanCategory.class);
+        Plan plan = mock(Plan.class);
+        CategoryState state = mock(CategoryState.class);
+        Trigger trigger = mock(Trigger.class);
+
+        given(planCategoryRepository.findByIdAndPlan_Id(categoryId, planId))
+                .willReturn(Optional.of(category));
+
+        given(category.getPlan()).willReturn(plan);
+        given(plan.getId()).willReturn(planId);
+
+        given(category.getId()).willReturn(categoryId);
+
+        given(categoryStateRepository.findByCategory_Id(categoryId))
+                .willReturn(Optional.of(state));
+
+        given(state.getCurrentCandidateId()).willReturn(currentCandidateId);
+
+        given(triggerRepository.save(any())).willReturn(trigger);
+
+        given(trigger.getId()).willReturn(100L);
+        given(trigger.getOccurredAt()).willReturn(LocalDateTime.now());
+
+        TriggerCreateResponse response =
+                triggerService.createTrigger(new TriggerCreateRequest(planId, categoryId, TriggerType.WEATHER_BAD));
+
+        assertThat(response.triggerId()).isEqualTo(100L);
+        verify(planStatsService).increaseTriggerCount(planId);
+    }
+
+    @Test
+    @DisplayName("트리거 생성 실패 - CategoryState 없음")
+    void createTrigger_categoryStateNotFound() {
+        PlanCategory category = mock(PlanCategory.class);
+
+        given(planCategoryRepository.findByIdAndPlan_Id(1L, 1L))
+                .willReturn(Optional.of(category));
+
+        given(categoryStateRepository.findByCategory_Id(any()))
+                .willReturn(Optional.empty());
+
+        assertThatThrownBy(() ->
+                triggerService.createTrigger(new TriggerCreateRequest(1L, 1L, TriggerType.FATIGUE))
+        )
+                .isInstanceOf(ApplicationException.class)
+                .satisfies(ex -> {
+                    ApplicationException ae = (ApplicationException) ex;
+                    assertThat(ae.getErrorCase()).isEqualTo(TriggerErrorCase.CATEGORY_STATE_NOT_FOUND);
+                });
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #37 

## 📝 작업 내용

**1. Trigger / Decision / Switch 컨트롤러 테스트**
- TriggerControllerTest
- DecisionControllerTest
- SwitchControllerTest
- 성공 및 주요 예외 케이스 검증


**2. 서비스 로직 테스트**
- TriggerServiceTest
- DecisionServiceTest
- SwitchServiceTest
- 비즈니스 로직에 대한 단위 테스트 및 도메인 규칙 검증

## 🖼️ 스크린샷 (선택)

> 모든 테스트코드 통과 확인 완료했습니다.

## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특히 봐주었으면 하는 부분이 있다면 작성해주세요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# 릴리즈 노트

* **Tests**
  * 트리거, 결정(Decision), 전환(Switch) 관련 컨트롤러 및 서비스에 대한 포괄적인 단위 테스트 추가
  * 성공 경로와 다양한 오류 처리(이미 결정됨, 존재하지 않는 리소스, 잘못된 요청 등)를 검증하는 시나리오 포함
  * 테스트 커버리지 및 경계 사례 검증 강화

* **Style**
  * 코드 포매팅(불필요한 공백 제거) 개선

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->