### PR TITLE
[feat] @CurrentUser 커스텀 어노테이션 도입

### DIFF
--- a/src/main/java/com/bready/server/global/auth/AuthUtils.java
+++ b/src/main/java/com/bready/server/global/auth/AuthUtils.java
@@ -19,6 +19,10 @@ public class AuthUtils {
 
         Object principal = authentication.getPrincipal();
 
+        if (principal == null) {
+            throw new ApplicationException(AuthErrorCase.INVALID_TOKEN);
+        }
+
         if (principal instanceof Long) {
             return (Long) principal;
         }

--- a/src/main/java/com/bready/server/global/auth/AuthUtils.java
+++ b/src/main/java/com/bready/server/global/auth/AuthUtils.java
@@ -39,7 +39,10 @@ public class AuthUtils {
         String header = request.getHeader("Authorization");
 
         if (header != null && header.startsWith("Bearer ")) {
-            return header.substring(7);
+            String token = header.substring(7).trim();
+            if (!token.isEmpty()) {
+                return token;
+            }
         }
 
         if (request.getCookies() != null) {

--- a/src/main/java/com/bready/server/global/auth/AuthUtils.java
+++ b/src/main/java/com/bready/server/global/auth/AuthUtils.java
@@ -1,0 +1,51 @@
+package com.bready.server.global.auth;
+
+import com.bready.server.auth.exception.AuthErrorCase;
+import com.bready.server.global.exception.ApplicationException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+public class AuthUtils {
+
+    public static Long getCurrentUserId() {
+        Authentication authentication =
+                SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication == null || !authentication.isAuthenticated()) {
+            throw new ApplicationException(AuthErrorCase.INVALID_TOKEN);
+        }
+
+        Object principal = authentication.getPrincipal();
+
+        if (principal instanceof Long) {
+            return (Long) principal;
+        }
+
+        try {
+            return Long.parseLong(principal.toString());
+        } catch (NumberFormatException e) {
+            throw new ApplicationException(AuthErrorCase.INVALID_TOKEN);
+        }
+    }
+
+    // Authorization 헤더 또는 쿠키에서 토큰 추출
+    public static String extractToken(HttpServletRequest request) {
+        String header = request.getHeader("Authorization");
+
+        if (header != null && header.startsWith("Bearer ")) {
+            return header.substring(7);
+        }
+
+        if (request.getCookies() != null) {
+            for (Cookie cookie : request.getCookies()) {
+                if ("accessToken".equals(cookie.getName())) {
+                    return cookie.getValue();
+                }
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/com/bready/server/global/auth/CurrentUser.java
+++ b/src/main/java/com/bready/server/global/auth/CurrentUser.java
@@ -1,0 +1,9 @@
+package com.bready.server.global.auth;
+
+import java.lang.annotation.*;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface CurrentUser {
+}

--- a/src/main/java/com/bready/server/global/auth/CurrentUserArgumentResolver.java
+++ b/src/main/java/com/bready/server/global/auth/CurrentUserArgumentResolver.java
@@ -1,10 +1,6 @@
 package com.bready.server.global.auth;
 
-import com.bready.server.auth.exception.AuthErrorCase;
-import com.bready.server.global.exception.ApplicationException;
 import org.springframework.core.MethodParameter;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.bind.support.WebDataBinderFactory;
 import org.springframework.web.context.request.NativeWebRequest;
@@ -27,22 +23,6 @@ public class CurrentUserArgumentResolver implements HandlerMethodArgumentResolve
             NativeWebRequest webRequest,
             WebDataBinderFactory binderFactory
     ) {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-
-        if (authentication == null || !authentication.isAuthenticated()) {
-            throw new ApplicationException(AuthErrorCase.INVALID_TOKEN);
-        }
-
-        Object principal = authentication.getPrincipal();
-
-        if (principal instanceof Long) {
-            return principal;
-        }
-
-        try {
-            return Long.parseLong(principal.toString());
-        } catch (NumberFormatException e) {
-            throw new ApplicationException(AuthErrorCase.INVALID_TOKEN);
-        }
+        return AuthUtils.getCurrentUserId();
     }
 }

--- a/src/main/java/com/bready/server/global/auth/CurrentUserArgumentResolver.java
+++ b/src/main/java/com/bready/server/global/auth/CurrentUserArgumentResolver.java
@@ -1,0 +1,48 @@
+package com.bready.server.global.auth;
+
+import com.bready.server.auth.exception.AuthErrorCase;
+import com.bready.server.global.exception.ApplicationException;
+import org.springframework.core.MethodParameter;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+public class CurrentUserArgumentResolver implements HandlerMethodArgumentResolver {
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(CurrentUser.class)
+                && Long.class.equals(parameter.getParameterType());
+    }
+
+    @Override
+    public Object resolveArgument(
+            MethodParameter parameter,
+            ModelAndViewContainer mavContainer,
+            NativeWebRequest webRequest,
+            WebDataBinderFactory binderFactory
+    ) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication == null || !authentication.isAuthenticated()) {
+            throw new ApplicationException(AuthErrorCase.INVALID_TOKEN);
+        }
+
+        Object principal = authentication.getPrincipal();
+
+        if (principal instanceof Long) {
+            return principal;
+        }
+
+        try {
+            return Long.parseLong(principal.toString());
+        } catch (NumberFormatException e) {
+            throw new ApplicationException(AuthErrorCase.INVALID_TOKEN);
+        }
+    }
+}

--- a/src/main/java/com/bready/server/global/auth/CurrentUserArgumentResolver.java
+++ b/src/main/java/com/bready/server/global/auth/CurrentUserArgumentResolver.java
@@ -13,7 +13,7 @@ public class CurrentUserArgumentResolver implements HandlerMethodArgumentResolve
     @Override
     public boolean supportsParameter(MethodParameter parameter) {
         return parameter.hasParameterAnnotation(CurrentUser.class)
-                && Long.class.equals(parameter.getParameterType());
+                && (Long.class.equals(parameter.getParameterType()) || long.class.equals(parameter.getParameterType()));
     }
 
     @Override

--- a/src/main/java/com/bready/server/global/config/WebConfig.java
+++ b/src/main/java/com/bready/server/global/config/WebConfig.java
@@ -1,0 +1,23 @@
+package com.bready.server.global.config;
+
+import com.bready.server.global.auth.CurrentUserArgumentResolver;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+
+    private final CurrentUserArgumentResolver currentUserArgumentResolver;
+
+    @Override
+    public void addArgumentResolvers(
+            List<HandlerMethodArgumentResolver> resolvers
+    ) {
+        resolvers.add(currentUserArgumentResolver);
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #39 

## 📝 작업 내용
**1. @CurrentUser 커스텀 파라미터 어노테이션 추가**
- 컨트롤러 메서드 파라미터에 붙이면 현재 로그인한 사용자 ID(Long) 를 자동으로 주입

**2. CurrentUserArgumentResolver 추가**
- @CurrentUser가 붙은 Long 파라미터를 감지
- AuthUtils 로직 위임

**3. WebMvcConfigurer에 Resolver 등록**
- WebConfig에서 CurrentUserArgumentResolver를 등록해 실제로 동작하도록 연결

## 🖼️ 스크린샷 (선택)

> UI 변경 등 시각적으로 확인할 수 있는 내용이 있다면 첨부해주세요

## 💬 리뷰 요구사항 (선택)

### @CurrentUser 사용 가이드
=> @CurrentUser는 **“지금 로그인한 사용자의 ID를 자동으로 꺼내주는 도구”**

### 언제 쓰는가?
=> 로그인한 사용자 기준으로 처리해야 할 때 전부 사용
- 내가 만든 플랜인지 확인해야 할 때
- 내가 발생시킨 트리거인지 검증해야 할 때
- 내 통계, 내 기록만 조회할 때 등등 
- 로그인 안 하면 못 쓰는 API는 @CurrentUser 사용

### 사용 예시
컨트롤러에서 현재 사용자 ID 받기 
```
@PostMapping("/ex")
public CommonResponse<?> example(
        @CurrentUser Long userId,
        @RequestBody @Valid SomeRequest request
) {
    return CommonResponse.success(service.example(userId, request));
}

```

=> @CurrentUser Long userId 한 줄로 현재 로그인 사용자 ID를 얻으면서 사용하고, SecurityContextHolder를 컨트롤러/서비스에서 직접 적용 X

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 컨트롤러에서 현재 로그인한 사용자 ID를 파라미터로 간편하게 주입해 사용할 수 있도록 지원
  * Authorization 헤더의 Bearer 토큰 또는 accessToken 쿠키에서 토큰을 자동으로 추출하고, 유효하지 않은 토큰에 대한 안전한 오류 처리를 추가하여 인증 흐름을 개선

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->