### PR TITLE
[feat] 카카오 로그인 API 구현

### DIFF
--- a/src/main/java/com/bready/server/auth/client/KakaoOAuthClient.java
+++ b/src/main/java/com/bready/server/auth/client/KakaoOAuthClient.java
@@ -2,7 +2,7 @@ package com.bready.server.auth.client;
 
 import com.bready.server.auth.config.KakaoOAuthProperties;
 import com.bready.server.auth.dto.KakaoTokenResponse;
-import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.util.LinkedMultiValueMap;
@@ -11,14 +11,20 @@ import org.springframework.web.reactive.function.BodyInserters;
 import org.springframework.web.reactive.function.client.WebClient;
 
 @Component
-@RequiredArgsConstructor
 public class KakaoOAuthClient {
 
     private static final String TOKEN_URI = "https://kauth.kakao.com/oauth/token";
 
     private final KakaoOAuthProperties properties;
+    private final WebClient webClient;
 
-    private final WebClient webClient = WebClient.builder().build();
+    public KakaoOAuthClient(
+            KakaoOAuthProperties properties,
+            @Qualifier("kakaoWebClient") WebClient webClient
+    ) {
+        this.properties = properties;
+        this.webClient = webClient;
+    }
 
     public KakaoTokenResponse getToken(String authorizationCode) {
         MultiValueMap<String, String> formData = new LinkedMultiValueMap<>();

--- a/src/main/java/com/bready/server/auth/client/KakaoOAuthClient.java
+++ b/src/main/java/com/bready/server/auth/client/KakaoOAuthClient.java
@@ -1,0 +1,40 @@
+package com.bready.server.auth.client;
+
+import com.bready.server.auth.config.KakaoOAuthProperties;
+import com.bready.server.auth.dto.KakaoTokenResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.reactive.function.BodyInserters;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Component
+@RequiredArgsConstructor
+public class KakaoOAuthClient {
+
+    private static final String TOKEN_URI = "https://kauth.kakao.com/oauth/token";
+
+    private final KakaoOAuthProperties properties;
+
+    private final WebClient webClient = WebClient.builder().build();
+
+    public KakaoTokenResponse getToken(String authorizationCode) {
+        MultiValueMap<String, String> formData = new LinkedMultiValueMap<>();
+        formData.add("grant_type", "authorization_code");
+        formData.add("client_id", properties.getClientId());
+        formData.add("client_secret", properties.getClientSecret());
+        formData.add("redirect_uri", properties.getRedirectUri());
+        formData.add("code", authorizationCode);
+
+        return webClient.post()
+                .uri(TOKEN_URI)
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                .body(BodyInserters.fromFormData(formData))
+                .retrieve()
+                .bodyToMono(KakaoTokenResponse.class)
+                .block();
+    }
+
+}

--- a/src/main/java/com/bready/server/auth/client/KakaoUserInfoClient.java
+++ b/src/main/java/com/bready/server/auth/client/KakaoUserInfoClient.java
@@ -1,0 +1,25 @@
+package com.bready.server.auth.client;
+
+import com.bready.server.auth.dto.KakaoUserInfoResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Component
+@RequiredArgsConstructor
+public class KakaoUserInfoClient {
+
+    private static final String USER_INFO_URI = "https://kapi.kakao.com/v2/user/me";
+
+    private final WebClient webClient = WebClient.builder().build();
+
+    public KakaoUserInfoResponse getUserInfo(String kakaoAccessToken) {
+        return webClient.get()
+                .uri(USER_INFO_URI)
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + kakaoAccessToken)
+                .retrieve()
+                .bodyToMono(KakaoUserInfoResponse.class)
+                .block();
+    }
+}

--- a/src/main/java/com/bready/server/auth/client/KakaoUserInfoClient.java
+++ b/src/main/java/com/bready/server/auth/client/KakaoUserInfoClient.java
@@ -1,18 +1,23 @@
 package com.bready.server.auth.client;
 
 import com.bready.server.auth.dto.KakaoUserInfoResponse;
-import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 
 @Component
-@RequiredArgsConstructor
 public class KakaoUserInfoClient {
 
     private static final String USER_INFO_URI = "https://kapi.kakao.com/v2/user/me";
 
-    private final WebClient webClient = WebClient.builder().build();
+    private final WebClient webClient;
+
+    public KakaoUserInfoClient(
+            @Qualifier("kakaoWebClient") WebClient webClient
+    ) {
+        this.webClient = webClient;
+    }
 
     public KakaoUserInfoResponse getUserInfo(String kakaoAccessToken) {
         return webClient.get()

--- a/src/main/java/com/bready/server/auth/config/KakaoOAuthProperties.java
+++ b/src/main/java/com/bready/server/auth/config/KakaoOAuthProperties.java
@@ -1,0 +1,17 @@
+package com.bready.server.auth.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "oauth.kakao")
+public class KakaoOAuthProperties {
+
+    private String clientId;
+    private String clientSecret;
+    private String redirectUri;
+}

--- a/src/main/java/com/bready/server/auth/controller/AuthController.java
+++ b/src/main/java/com/bready/server/auth/controller/AuthController.java
@@ -1,11 +1,8 @@
 package com.bready.server.auth.controller;
 
-import com.bready.server.auth.dto.LoginRequest;
-import com.bready.server.auth.dto.RefreshRequest;
-import com.bready.server.auth.dto.SignupRequest;
-import com.bready.server.auth.dto.SignupResponse;
-import com.bready.server.auth.dto.TokenResponse;
+import com.bready.server.auth.dto.*;
 import com.bready.server.auth.service.AuthService;
+import com.bready.server.auth.service.KakaoAuthService;
 import com.bready.server.global.response.CommonResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -22,8 +19,8 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 public class AuthController {
 
-
     private final AuthService authService;
+    private final KakaoAuthService kakaoAuthService;
 
 
     @PostMapping("/signup")
@@ -86,5 +83,27 @@ public class AuthController {
             @Valid @RequestBody RefreshRequest request
     ) {
         return CommonResponse.success(authService.refresh(request));
+    }
+
+    @PostMapping("/kakao/login")
+    @ResponseStatus(HttpStatus.OK)
+    @Operation(
+            summary = "카카오 로그인",
+            description = "인가 코드로 카카오 인증 후 access, refresh 토큰 발급, 사용자 정보 반환"
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "카카오 로그인 성공",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "400", description = "이메일 제공 동의 필수",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "401", description = "유효하지 않은 카카오 인증 정보",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "502", description = "카카오 인증 서버 통신 실패",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class)))
+    })
+    public CommonResponse<KakaoLoginResponse> kakaoLogin(
+            @Valid @RequestBody KaKaoLoginRequest request
+    ) {
+        return CommonResponse.success(kakaoAuthService.login(request));
     }
 }

--- a/src/main/java/com/bready/server/auth/controller/AuthController.java
+++ b/src/main/java/com/bready/server/auth/controller/AuthController.java
@@ -102,7 +102,7 @@ public class AuthController {
                     content = @Content(schema = @Schema(implementation = CommonResponse.class)))
     })
     public CommonResponse<KakaoLoginResponse> kakaoLogin(
-            @Valid @RequestBody KaKaoLoginRequest request
+            @Valid @RequestBody KakaoLoginRequest request
     ) {
         return CommonResponse.success(kakaoAuthService.login(request));
     }

--- a/src/main/java/com/bready/server/auth/dto/KaKaoLoginRequest.java
+++ b/src/main/java/com/bready/server/auth/dto/KaKaoLoginRequest.java
@@ -1,0 +1,10 @@
+package com.bready.server.auth.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public class KaKaoLoginRequest {
+
+    @NotBlank(message = "인가 코드는 필수입니다.")
+    private String code;
+
+}

--- a/src/main/java/com/bready/server/auth/dto/KaKaoLoginRequest.java
+++ b/src/main/java/com/bready/server/auth/dto/KaKaoLoginRequest.java
@@ -1,7 +1,9 @@
 package com.bready.server.auth.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
 
+@Getter
 public class KaKaoLoginRequest {
 
     @NotBlank(message = "인가 코드는 필수입니다.")

--- a/src/main/java/com/bready/server/auth/dto/KakaoLoginRequest.java
+++ b/src/main/java/com/bready/server/auth/dto/KakaoLoginRequest.java
@@ -2,9 +2,11 @@ package com.bready.server.auth.dto;
 
 import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
-public class KaKaoLoginRequest {
+@NoArgsConstructor
+public class KakaoLoginRequest {
 
     @NotBlank(message = "인가 코드는 필수입니다.")
     private String code;

--- a/src/main/java/com/bready/server/auth/dto/KakaoLoginResponse.java
+++ b/src/main/java/com/bready/server/auth/dto/KakaoLoginResponse.java
@@ -1,0 +1,23 @@
+package com.bready.server.auth.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class KakaoLoginResponse {
+
+    private String accessToken;
+    private String refreshToken;
+    private boolean isNewUser;
+    private UserDto user;
+
+    @Getter
+    @Builder
+    public static class UserDto {
+        private Long userId;
+        private String nickname;
+        private String email;
+        private String joinedAt;
+    }
+}

--- a/src/main/java/com/bready/server/auth/dto/KakaoTokenResponse.java
+++ b/src/main/java/com/bready/server/auth/dto/KakaoTokenResponse.java
@@ -1,0 +1,27 @@
+package com.bready.server.auth.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class KakaoTokenResponse {
+
+    @JsonProperty("access_token")
+    private String accessToken;
+
+    @JsonProperty("token_type")
+    private String tokenType;
+
+    @JsonProperty("expires_in")
+    private Integer expiresIn;
+
+    @JsonProperty("refresh_token")
+    private String refreshToken;
+
+    @JsonProperty("refresh_token_expires_in")
+    private Integer refreshTokenExpiresIn;
+
+    private String scope;
+}

--- a/src/main/java/com/bready/server/auth/dto/KakaoUserInfoResponse.java
+++ b/src/main/java/com/bready/server/auth/dto/KakaoUserInfoResponse.java
@@ -1,0 +1,30 @@
+package com.bready.server.auth.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class KakaoUserInfoResponse {
+
+    private Long id;
+
+    @JsonProperty("kakao_account")
+    private KakaoAccount kakaoAccount;
+
+    @JsonProperty("properties")
+    private Properties properties;
+
+    @Getter
+    @NoArgsConstructor
+    public static class KakaoAccount {
+        private String email;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    public static class Properties {
+        private String nickname;
+    }
+}

--- a/src/main/java/com/bready/server/auth/exception/AuthErrorCase.java
+++ b/src/main/java/com/bready/server/auth/exception/AuthErrorCase.java
@@ -20,8 +20,11 @@ public enum AuthErrorCase implements ErrorCase {
     INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, 4011, "이메일 또는 비밀번호가 올바르지 않습니다."),
 
     // refresh 전용
-    REFRESH_TOKEN_INVALID(HttpStatus.UNAUTHORIZED, 4012, "리프레시 토큰이 유효하지 않습니다.");
+    REFRESH_TOKEN_INVALID(HttpStatus.UNAUTHORIZED, 4012, "리프레시 토큰이 유효하지 않습니다."),
 
+    // 카카오 소셜 로그인
+    INVALID_KAKAO_AUTH(HttpStatus.UNAUTHORIZED, 4013,"유효하지 않은 카카오 인증 정보입니다."),
+    KAKAO_API_COMMUNICATION_FAILED(HttpStatus.BAD_GATEWAY, 5021, "카카오 인증 서버와 통신에 실패했습니다.");
 
     private final HttpStatus httpStatus;
     private final Integer errorCode;

--- a/src/main/java/com/bready/server/auth/service/AuthService.java
+++ b/src/main/java/com/bready/server/auth/service/AuthService.java
@@ -44,7 +44,7 @@ public class AuthService {
 
             // 2) User 저장
             String encoded = passwordEncoder.encode(request.getPassword());
-            User user = userRepository.save(User.create(request.getEmail(), encoded));
+            User user = userRepository.save(User.createLocal(request.getEmail(), encoded));
 
             // 3) UserProfile 저장
             UserProfile profile = userProfileRepository.save(

--- a/src/main/java/com/bready/server/auth/service/KakaoAuthService.java
+++ b/src/main/java/com/bready/server/auth/service/KakaoAuthService.java
@@ -33,7 +33,7 @@ public class KakaoAuthService {
     private final TokenIssuer tokenIssuer;
 
     @Transactional
-    public KakaoLoginResponse login(KaKaoLoginRequest request) {
+    public KakaoLoginResponse login(KakaoLoginRequest request) {
 
         // 인가 코드 검증
         String code = request.getCode();

--- a/src/main/java/com/bready/server/auth/service/KakaoAuthService.java
+++ b/src/main/java/com/bready/server/auth/service/KakaoAuthService.java
@@ -32,7 +32,6 @@ public class KakaoAuthService {
     private final UserProfileRepository userProfileRepository;
     private final TokenIssuer tokenIssuer;
 
-    @Transactional
     public KakaoLoginResponse login(KakaoLoginRequest request) {
 
         // 인가 코드 검증
@@ -53,6 +52,12 @@ public class KakaoAuthService {
         if (userInfo.getId() == null) {
             throw new ApplicationException(AuthErrorCase.INVALID_KAKAO_AUTH);
         }
+
+        return processKakaoLogin(userInfo);
+    }
+
+    @Transactional
+    protected KakaoLoginResponse processKakaoLogin(KakaoUserInfoResponse userInfo) {
 
         String providerUserId = String.valueOf(userInfo.getId());
 

--- a/src/main/java/com/bready/server/auth/service/KakaoAuthService.java
+++ b/src/main/java/com/bready/server/auth/service/KakaoAuthService.java
@@ -5,21 +5,9 @@ import com.bready.server.auth.client.KakaoUserInfoClient;
 import com.bready.server.auth.dto.*;
 import com.bready.server.auth.exception.AuthErrorCase;
 import com.bready.server.global.exception.ApplicationException;
-import com.bready.server.user.domain.User;
-import com.bready.server.user.domain.UserAuthProvider;
-import com.bready.server.user.domain.UserProfile;
-import com.bready.server.user.exception.UserErrorCase;
-import com.bready.server.user.repository.UserProfileRepository;
-import com.bready.server.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
-
-import java.time.ZoneOffset;
-import java.time.format.DateTimeFormatter;
-import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -28,100 +16,29 @@ public class KakaoAuthService {
     private final KakaoOAuthClient kakaoOAuthClient;
     private final KakaoUserInfoClient kakaoUserInfoClient;
 
-    private final UserRepository userRepository;
-    private final UserProfileRepository userProfileRepository;
-    private final TokenIssuer tokenIssuer;
+    private final KakaoAuthTransactionHandler kakaoAuthTransactionHandler;
 
     public KakaoLoginResponse login(KakaoLoginRequest request) {
 
-        // 인가 코드 검증
         String code = request.getCode();
         if (code == null || code.isBlank()) {
             throw new ApplicationException(AuthErrorCase.INVALID_KAKAO_AUTH);
         }
 
-        // 카카오 토큰 교환
+        // 카카오 토큰 교환 (트랜잭션 외부)
         KakaoTokenResponse token = exchangeKakaoToken(code);
         String kakaoAccessToken = token.getAccessToken();
         if (kakaoAccessToken == null || kakaoAccessToken.isBlank()) {
             throw new ApplicationException(AuthErrorCase.INVALID_KAKAO_AUTH);
         }
 
-        // 사용자 정보 조회
+        // 사용자 정보 조회 (트랜잭션 외부)
         KakaoUserInfoResponse userInfo = fetchKakaoUserInfo(kakaoAccessToken);
         if (userInfo.getId() == null) {
             throw new ApplicationException(AuthErrorCase.INVALID_KAKAO_AUTH);
         }
 
-        return processKakaoLogin(userInfo);
-    }
-
-    @Transactional
-    protected KakaoLoginResponse processKakaoLogin(KakaoUserInfoResponse userInfo) {
-
-        String providerUserId = String.valueOf(userInfo.getId());
-
-        User user = userRepository
-                .findByAuthProviderAndProviderUserId(UserAuthProvider.KAKAO, providerUserId)
-                .orElse(null);
-
-        boolean isNewUser = false;
-
-        if (user == null) {
-
-            String email = (userInfo.getKakaoAccount() == null) ? null : userInfo.getKakaoAccount().getEmail();
-            if (email == null || email.isBlank()) {
-                throw new ApplicationException(UserErrorCase.KAKAO_EMAIL_CONSENT_REQUIRED);
-            }
-
-            if (userRepository.existsByEmail(email)) {
-                throw new ApplicationException(UserErrorCase.DUPLICATED_EMAIL);
-            }
-
-            String nickname = (userInfo.getProperties() == null) ? null : userInfo.getProperties().getNickname();
-            if (nickname == null || nickname.isBlank()) {
-                nickname = generateRandomNickname();
-            }
-
-            isNewUser = true;
-            try {
-                user = userRepository.save(
-                        User.createSocial(UserAuthProvider.KAKAO, providerUserId, email)
-                );
-                userProfileRepository.save(UserProfile.create(user, nickname));
-            } catch (DataIntegrityViolationException e) {
-                user = userRepository
-                        .findByAuthProviderAndProviderUserId(UserAuthProvider.KAKAO, providerUserId)
-                        .orElseThrow(() -> e);
-                isNewUser = false;
-            }
-        }
-
-        // 토큰 발급
-        TokenResponse tokens = tokenIssuer.issue(user.getId());
-
-        User userWithProfile = userRepository.findByIdWithProfile(user.getId())
-                .orElseThrow(() -> new ApplicationException(AuthErrorCase.INVALID_KAKAO_AUTH));
-
-        String joinedAt = userWithProfile.getCreatedAt() == null ? null
-                : userWithProfile.getCreatedAt().atOffset(ZoneOffset.UTC)
-                .format(DateTimeFormatter.ISO_OFFSET_DATE_TIME);
-
-        String nicknameForResponse = userWithProfile.getUserProfile() != null
-                ? userWithProfile.getUserProfile().getNickname()
-                : null;
-
-        return KakaoLoginResponse.builder()
-                .accessToken(tokens.getAccessToken())
-                .refreshToken(tokens.getRefreshToken())
-                .isNewUser(isNewUser)
-                .user(KakaoLoginResponse.UserDto.builder()
-                        .userId(user.getId())
-                        .nickname(nicknameForResponse)
-                        .email(user.getEmail())
-                        .joinedAt(joinedAt)
-                        .build())
-                .build();
+        return kakaoAuthTransactionHandler.processKakaoLogin(userInfo);
     }
 
     private KakaoTokenResponse exchangeKakaoToken(String code) {
@@ -148,9 +65,5 @@ public class KakaoAuthService {
         } catch (Exception e) {
             throw new ApplicationException(AuthErrorCase.KAKAO_API_COMMUNICATION_FAILED);
         }
-    }
-
-    private String generateRandomNickname() {
-        return "사용자" + UUID.randomUUID().toString().replace("-", "").substring(0, 8);
     }
 }

--- a/src/main/java/com/bready/server/auth/service/KakaoAuthTransactionHandler.java
+++ b/src/main/java/com/bready/server/auth/service/KakaoAuthTransactionHandler.java
@@ -1,0 +1,100 @@
+package com.bready.server.auth.service;
+
+import com.bready.server.auth.dto.*;
+import com.bready.server.auth.exception.AuthErrorCase;
+import com.bready.server.global.exception.ApplicationException;
+import com.bready.server.user.domain.User;
+import com.bready.server.user.domain.UserAuthProvider;
+import com.bready.server.user.domain.UserProfile;
+import com.bready.server.user.exception.UserErrorCase;
+import com.bready.server.user.repository.UserProfileRepository;
+import com.bready.server.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class KakaoAuthTransactionHandler {
+
+    private final UserRepository userRepository;
+    private final UserProfileRepository userProfileRepository;
+    private final TokenIssuer tokenIssuer;
+
+    @Transactional
+    public KakaoLoginResponse processKakaoLogin(KakaoUserInfoResponse userInfo) {
+
+        String providerUserId = String.valueOf(userInfo.getId());
+
+        User user = userRepository
+                .findByAuthProviderAndProviderUserId(UserAuthProvider.KAKAO, providerUserId)
+                .orElse(null);
+
+        boolean isNewUser = false;
+
+        if (user == null) {
+
+            String email = (userInfo.getKakaoAccount() == null) ? null : userInfo.getKakaoAccount().getEmail();
+            if (email == null || email.isBlank()) {
+                throw new ApplicationException(UserErrorCase.KAKAO_EMAIL_CONSENT_REQUIRED);
+            }
+
+            if (userRepository.existsByEmail(email)) {
+                throw new ApplicationException(UserErrorCase.DUPLICATED_EMAIL);
+            }
+
+            String nickname = (userInfo.getProperties() == null) ? null : userInfo.getProperties().getNickname();
+            if (nickname == null || nickname.isBlank()) {
+                nickname = generateRandomNickname();
+            }
+
+            isNewUser = true;
+
+            try {
+                user = userRepository.save(
+                        User.createSocial(UserAuthProvider.KAKAO, providerUserId, email)
+                );
+                userProfileRepository.save(UserProfile.create(user, nickname));
+            } catch (DataIntegrityViolationException e) {
+                user = userRepository
+                        .findByAuthProviderAndProviderUserId(UserAuthProvider.KAKAO, providerUserId)
+                        .orElseThrow(() -> e);
+                isNewUser = false;
+            }
+        }
+
+        TokenResponse tokens = tokenIssuer.issue(user.getId());
+
+        User userWithProfile = userRepository.findByIdWithProfile(user.getId())
+                .orElseThrow(() -> new ApplicationException(AuthErrorCase.INVALID_KAKAO_AUTH));
+
+        String joinedAt = userWithProfile.getCreatedAt() == null ? null
+                : userWithProfile.getCreatedAt().atOffset(ZoneOffset.UTC)
+                .format(DateTimeFormatter.ISO_OFFSET_DATE_TIME);
+
+        String nicknameForResponse = userWithProfile.getUserProfile() != null
+                ? userWithProfile.getUserProfile().getNickname()
+                : null;
+
+        return KakaoLoginResponse.builder()
+                .accessToken(tokens.getAccessToken())
+                .refreshToken(tokens.getRefreshToken())
+                .isNewUser(isNewUser)
+                .user(KakaoLoginResponse.UserDto.builder()
+                        .userId(user.getId())
+                        .nickname(nicknameForResponse)
+                        .email(user.getEmail())
+                        .joinedAt(joinedAt)
+                        .build())
+                .build();
+    }
+
+    private String generateRandomNickname() {
+        return "사용자" + UUID.randomUUID().toString().replace("-", "").substring(0, 8);
+    }
+}

--- a/src/main/java/com/bready/server/auth/service/KakaoAuthTransactionHandler.java
+++ b/src/main/java/com/bready/server/auth/service/KakaoAuthTransactionHandler.java
@@ -61,10 +61,16 @@ public class KakaoAuthTransactionHandler {
                 );
                 userProfileRepository.save(UserProfile.create(user, nickname));
             } catch (DataIntegrityViolationException e) {
+                if (userRepository.existsByEmail(email)) {
+                    throw new ApplicationException(UserErrorCase.DUPLICATED_EMAIL);
+                }
+
+                isNewUser = false;
+
                 user = userRepository
                         .findByAuthProviderAndProviderUserId(UserAuthProvider.KAKAO, providerUserId)
                         .orElseThrow(() -> e);
-                isNewUser = false;
+
             }
         }
 

--- a/src/main/java/com/bready/server/auth/service/TokenIssuer.java
+++ b/src/main/java/com/bready/server/auth/service/TokenIssuer.java
@@ -1,0 +1,35 @@
+package com.bready.server.auth.service;
+
+import com.bready.server.auth.domain.RefreshToken;
+import com.bready.server.auth.dto.TokenResponse;
+import com.bready.server.auth.repository.RefreshTokenRepository;
+import com.bready.server.global.config.security.jwt.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class TokenIssuer {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    public TokenResponse issue(Long userId) {
+
+        String accessToken = jwtTokenProvider.generateAccessToken(userId);
+        String refreshToken = jwtTokenProvider.generateRefreshToken(userId);
+
+        refreshTokenRepository.save(
+                RefreshToken.builder()
+                        .key(String.valueOf(userId))
+                        .token(refreshToken)
+                        .userId(userId)
+                        .build()
+        );
+
+        return TokenResponse.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+    }
+}

--- a/src/main/java/com/bready/server/user/domain/User.java
+++ b/src/main/java/com/bready/server/user/domain/User.java
@@ -6,7 +6,13 @@ import lombok.Getter;
 
 @Entity
 @Getter
-@Table(name = "users")
+@Table(name = "users",
+uniqueConstraints = {
+        @UniqueConstraint(
+                name = "uk_users_provider",
+                columnNames = {"auth_provider", "provider_user_id"}
+        )
+})
 public class User extends BaseEntity {
 
     @Id
@@ -19,16 +25,35 @@ public class User extends BaseEntity {
     private String password;
 
     @Enumerated(EnumType.STRING)
+    @Column(name = "auth_provider", nullable = false)
+    private UserAuthProvider authProvider;
+
+    @Column(name = "provider_user_id")
+    private String providerUserId;
+
+    @Enumerated(EnumType.STRING)
     private UserStatus status;
 
     @OneToOne(mappedBy = "user")
     private UserProfile userProfile;
 
-    public static User create(String email, String encodedPassword) {
+    public static User createLocal(String email, String encodedPassword) {
         User user = new User();
         user.email = email;
         user.password = encodedPassword;
         user.status = UserStatus.ACTIVE;
+        user.authProvider = UserAuthProvider.LOCAL;
+        user.providerUserId = null;
+        return user;
+    }
+
+    public static User createSocial(UserAuthProvider provider, String providerUserId, String email) {
+        User user = new User();
+        user.email = email;
+        user.password = null;
+        user.status = UserStatus.ACTIVE;
+        user.authProvider = provider;
+        user.providerUserId = providerUserId;
         return user;
     }
 }

--- a/src/main/java/com/bready/server/user/domain/User.java
+++ b/src/main/java/com/bready/server/user/domain/User.java
@@ -48,6 +48,10 @@ public class User extends BaseEntity {
     }
 
     public static User createSocial(UserAuthProvider provider, String providerUserId, String email) {
+        if (providerUserId == null || providerUserId.isBlank()) {
+            throw new IllegalArgumentException("providerUserId must not be blank");
+        }
+
         User user = new User();
         user.email = email;
         user.password = null;

--- a/src/main/java/com/bready/server/user/domain/UserAuthProvider.java
+++ b/src/main/java/com/bready/server/user/domain/UserAuthProvider.java
@@ -1,0 +1,7 @@
+package com.bready.server.user.domain;
+
+public enum UserAuthProvider {
+    LOCAL,
+    KAKAO,
+    NAVER
+}

--- a/src/main/java/com/bready/server/user/exception/UserErrorCase.java
+++ b/src/main/java/com/bready/server/user/exception/UserErrorCase.java
@@ -19,7 +19,10 @@ public enum UserErrorCase implements ErrorCase {
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, 4041, "사용자 정보를 찾을 수 없습니다."),
 
     // 회원가입 이메일 중복
-    DUPLICATED_EMAIL(HttpStatus.CONFLICT, 4091, "이미 사용 중인 이메일입니다.");
+    DUPLICATED_EMAIL(HttpStatus.CONFLICT, 4091, "이미 사용 중인 이메일입니다."),
+
+    // 소셜 로그인
+    KAKAO_EMAIL_CONSENT_REQUIRED(HttpStatus.BAD_REQUEST, 4104, "이메일 제공에 동의해야 가입/로그인이 가능합니다.");
 
     private final HttpStatus httpStatus;
     private final Integer errorCode;

--- a/src/main/java/com/bready/server/user/repository/UserRepository.java
+++ b/src/main/java/com/bready/server/user/repository/UserRepository.java
@@ -1,6 +1,7 @@
 package com.bready.server.user.repository;
 
 import com.bready.server.user.domain.User;
+import com.bready.server.user.domain.UserAuthProvider;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
@@ -11,6 +12,11 @@ public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByEmail(String email);
 
     Optional<User> findByEmail(String email);
+
+    Optional<User> findByAuthProviderAndProviderUserId(
+            UserAuthProvider authProvider,
+            String providerUserId
+    );
 
     @Query("""
         select u from User u

--- a/src/main/java/com/bready/server/user/repository/UserRepository.java
+++ b/src/main/java/com/bready/server/user/repository/UserRepository.java
@@ -4,6 +4,7 @@ import com.bready.server.user.domain.User;
 import com.bready.server.user.domain.UserAuthProvider;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
@@ -23,6 +24,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
         join fetch u.userProfile
         where u.id = :userId
     """)
-    Optional<User> findByIdWithProfile(Long userId);
+    Optional<User> findByIdWithProfile(@Param("userId") Long userId);
 
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #41 

## 📝 작업 내용

- OAuth 인증 구조 분리 및 서비스 정리
- 카카오 OAuth 로그인 기능 구현
- 카카오 로그인 관련 DTO 및 예외 처리 추가

## 🖼️ 스크린샷 (선택)

### 카카오 로그인 성공
<img width="561" height="581" alt="image" src="https://github.com/user-attachments/assets/d75642d2-28ec-4c9a-9706-e9a35c139b56" />

###  실패
<img width="883" height="225" alt="스크린샷 2026-01-30 085822" src="https://github.com/user-attachments/assets/1f57e102-b174-43f1-bf33-0dab049e94e9" />




## 💬 리뷰 요구사항 (선택)
> 리뷰어가 특히 봐주었으면 하는 부분이 있다면 작성해주세요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 카카오 소셜 로그인 지원: 카카오 계정으로 가입/로그인 가능.
  * 신규 로그인 API 제공: 카카오 인증 코드 기반 /kakao/login 엔드포인트 추가.
  * 소셜 계정 연동 지원: 소셜 제공자 기반 가입 흐름 및 사용자 정보 처리 개선.
* **Behavior / UX**
  * 이메일 제공 동의 필요 안내 추가; 미동의 시 가입/로그인 차단.
  * 카카오 관련 인증 및 외부 API 통신 오류에 대한 명확한 응답 개선.
  * 카카오 프로필에 닉네임 없을 경우 자동 닉네임 생성으로 사용자 경험 보완.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->