### PR TITLE
[fix] 카카오 외부 검색 API에서 유저가 검색 (키워드) 하지 못하는 오류 해결 

### DIFF
--- a/src/main/java/com/bready/server/place/controller/PlaceSearchController.java
+++ b/src/main/java/com/bready/server/place/controller/PlaceSearchController.java
@@ -59,6 +59,7 @@ public class PlaceSearchController {
                     example = "CAFE"
             )
             @RequestParam PlaceCategoryType category,
+            @RequestParam(required = false) String keyword,
 
             @Parameter(
                     name = "latitude",
@@ -98,7 +99,7 @@ public class PlaceSearchController {
         }
 
         List<PlaceSearchResponse> results =
-                placeSearchService.search(category, latitude, longitude, radius);
+                placeSearchService.search(category, keyword, latitude, longitude, radius);
 
         // 결과 없으면 에러 처리
         if (results.isEmpty()) {

--- a/src/main/java/com/bready/server/place/service/PlaceSearchService.java
+++ b/src/main/java/com/bready/server/place/service/PlaceSearchService.java
@@ -4,15 +4,18 @@ import com.bready.server.global.exception.ApplicationException;
 import com.bready.server.place.domain.PlaceCategoryType;
 import com.bready.server.place.dto.PlaceSearchResponse;
 import com.bready.server.place.dto.kakao.KakaoPlaceDocument;
+import com.bready.server.place.exception.PlaceErrorCase;
 import com.bready.server.place.external.KakaoPlaceClient;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-import com.bready.server.place.exception.PlaceErrorCase;
+
 import java.math.BigDecimal;
 import java.util.List;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class PlaceSearchService {
@@ -22,12 +25,23 @@ public class PlaceSearchService {
 
     public List<PlaceSearchResponse> search(
             PlaceCategoryType category,
+            String keyword,
             Double latitude,
             Double longitude,
             Integer radius
     ) {
+        String searchKeyword;
+
+        if (keyword != null && !keyword.isBlank()) {
+            searchKeyword = keyword + " " + category.getKeyword();
+        } else {
+            searchKeyword = category.getKeyword();
+        }
+
+        log.info("카카오 검색어 = {}", searchKeyword);
+
         String response = kakaoPlaceClient.search(
-                category.getKeyword(),
+                searchKeyword,
                 latitude,
                 longitude,
                 radius,
@@ -42,6 +56,10 @@ public class PlaceSearchService {
             List<KakaoPlaceDocument> kakaoPlaces =
                     objectMapper.readerForListOf(KakaoPlaceDocument.class)
                             .readValue(documents.toString());
+
+            if (kakaoPlaces.isEmpty()) {
+                throw ApplicationException.from(PlaceErrorCase.PLACE_NOT_FOUND);
+            }
 
             return kakaoPlaces.stream()
                     .map(p -> PlaceSearchResponse.builder()
@@ -59,6 +77,8 @@ public class PlaceSearchService {
                     )
                     .toList();
 
+        } catch (ApplicationException e) {
+            throw e;
         } catch (Exception e) {
             throw new ApplicationException(PlaceErrorCase.KAKAO_RESPONSE_PARSE_FAILED, e);
         }

--- a/src/main/java/com/bready/server/plan/domain/PlanCategory.java
+++ b/src/main/java/com/bready/server/plan/domain/PlanCategory.java
@@ -1,6 +1,7 @@
 package com.bready.server.plan.domain;
 
 import com.bready.server.global.entity.BaseEntity;
+import com.bready.server.place.domain.PlaceCategoryType;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -17,7 +18,8 @@ public class PlanCategory extends BaseEntity {
     private Long id;
 
     @Column(name = "category_type", nullable = false)
-    private String categoryType;
+    @Enumerated(EnumType.STRING)
+    private PlaceCategoryType categoryType;
 
     @Column(nullable = false)
     private Integer sequence;

--- a/src/test/java/com/bready/server/place/controller/PlaceSearchControllerTest.java
+++ b/src/test/java/com/bready/server/place/controller/PlaceSearchControllerTest.java
@@ -40,7 +40,7 @@ class PlaceSearchControllerTest {
     void search_success() throws Exception {
         given(placeSearchService.search(
                 eq(PlaceCategoryType.CAFE),
-                eq("성수"),
+                any(),
                 eq(37.544),
                 eq(127.055),
                 eq(2000)
@@ -61,7 +61,7 @@ class PlaceSearchControllerTest {
                         .param("longitude", "127.055")
                 )
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.message").value("success"))
+                .andExpect(jsonPath("$.data").isArray())
                 .andExpect(jsonPath("$.data[0].name").value("성수 카페"));
     }
 

--- a/src/test/java/com/bready/server/place/controller/PlaceSearchControllerTest.java
+++ b/src/test/java/com/bready/server/place/controller/PlaceSearchControllerTest.java
@@ -40,6 +40,7 @@ class PlaceSearchControllerTest {
     void search_success() throws Exception {
         given(placeSearchService.search(
                 eq(PlaceCategoryType.CAFE),
+                eq("성수"),
                 eq(37.544),
                 eq(127.055),
                 eq(2000)
@@ -79,7 +80,7 @@ class PlaceSearchControllerTest {
     @Test
     @DisplayName("결과 없음 → PLACE_NOT_FOUND")
     void search_empty_result() throws Exception {
-        given(placeSearchService.search(any(), any(), any(), any()))
+        given(placeSearchService.search(any(), any(), any(), any(), any()))
                 .willReturn(List.of());
 
         mockMvc.perform(get("/api/v1/places/search")

--- a/src/test/java/com/bready/server/place/service/PlaceSearchServiceTest.java
+++ b/src/test/java/com/bready/server/place/service/PlaceSearchServiceTest.java
@@ -56,6 +56,7 @@ class PlaceSearchServiceTest {
         List<PlaceSearchResponse> result =
                 placeSearchService.search(
                         PlaceCategoryType.CAFE,
+                        "성수",
                         37.544,
                         127.055,
                         2000
@@ -80,6 +81,7 @@ class PlaceSearchServiceTest {
         assertThatThrownBy(() ->
                 placeSearchService.search(
                         PlaceCategoryType.CAFE,
+                        "성수",
                         37.0,
                         127.0,
                         2000


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝 작업 내용
카카오 외부 API (거리 기반 카테고리 연동) 에서 사용자가 카테고리에 따라 원하는 키워드를 검색해야하는데 해당 키워드가 없어서 검색해도 엉뚱한 곳이 나와버리는 문제가 있어서 해당 문제를 해결하였습니다. (로직에 사용자 검색이 가능하도록 키워드 필드 추가) 


## 🖼️ 스크린샷 (선택)
### 실제 거리기반 음식점으로 검색 후 장소 추가 성공
 
<img width="1919" height="939" alt="음식점연동성공" src="https://github.com/user-attachments/assets/6f8014d3-7c00-4fd0-970a-f00cded6038a" />

### 대표 장소 변경 성공
<img width="1919" height="945" alt="대표장소변경연동성공" src="https://github.com/user-attachments/assets/ffa6b16d-9aeb-46bf-a00b-b5aaa384b0a7" />


## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특히 봐주었으면 하는 부분이 있다면 작성해주세요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 장소 검색 API에 선택적 키워드 검색 옵션 추가 — 카테고리 외 키워드로도 장소 탐색 가능.
  * 검색 결과가 없을 경우 명확한 오류 응답(PLACE_NOT_FOUND) 반환.

* **개선 사항**
  * 카테고리 타입을 열거형으로 변경해 데이터 일관성 강화.

* **테스트**
  * 키워드 인자를 반영한 검색 관련 테스트 케이스 업데이트 및 추가.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->