### PR TITLE
[feat] 플랜 도메인 기본 CRUD API 구현

### DIFF
--- a/src/main/java/com/bready/server/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/bready/server/global/config/security/SecurityConfig.java
@@ -57,9 +57,7 @@ public class SecurityConfig {
                         .requestMatchers("/actuator/health", "/actuator/info").permitAll()
                         .requestMatchers("/api/v1/auth/**").permitAll()
                         .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
-
-                        // TODO: 로그인,회원가입 API 구현 후 .anyRequest().authenticated() 로 변경
-                        .anyRequest().permitAll()
+                        .anyRequest().authenticated()
                 )
                 .addFilterBefore(
                         new JwtAuthenticationFilter(jwtTokenProvider),
@@ -68,6 +66,7 @@ public class SecurityConfig {
                 // 기본 인증 방식 비활성화
                 .formLogin(form -> form.disable())
                 .httpBasic(basic -> basic.disable());
+
         return http.build();
     }
 

--- a/src/main/java/com/bready/server/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/bready/server/global/exception/GlobalExceptionHandler.java
@@ -49,11 +49,22 @@ public class GlobalExceptionHandler {
     public ResponseEntity<CommonResponse<?>> handleHttpMessageNotReadable(HttpMessageNotReadableException e) {
         Throwable cause = e.getCause();
 
-        if (cause instanceof InvalidFormatException) {
+        if (cause instanceof InvalidFormatException ife) {
+            String fieldName = ife.getPath().isEmpty()
+                    ? null
+                    : ife.getPath().get(ife.getPath().size() - 1).getFieldName();
+
             log.warn("[HttpMessageNotReadable] {}", e.getMessage());
+
+            if ("planDate".equals(fieldName)) {
+                return ResponseEntity
+                        .status(HttpStatus.BAD_REQUEST)
+                        .body(CommonResponse.error(4006, "planDate 형식이 올바르지 않습니다."));
+            }
+
             return ResponseEntity
                     .status(HttpStatus.BAD_REQUEST)
-                    .body(CommonResponse.error(4006, "planDate 형식이 올바르지 않습니다."));
+                    .body(CommonResponse.error(4001, "요청 값이 유효하지 않습니다."));
         }
 
         log.warn("[HttpMessageNotReadable] {}", e.getMessage());

--- a/src/main/java/com/bready/server/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/bready/server/global/exception/GlobalExceptionHandler.java
@@ -1,10 +1,12 @@
 package com.bready.server.global.exception;
 
 import com.bready.server.global.response.CommonResponse;
+import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.validation.ObjectError;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
@@ -38,6 +40,23 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .status(HttpStatus.BAD_REQUEST)
                 .body(CommonResponse.error(4001, message));
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<CommonResponse<?>> handleHttpMessageNotReadable(HttpMessageNotReadableException e) {
+        Throwable cause = e.getCause();
+
+        if (cause instanceof InvalidFormatException) {
+            log.warn("[HttpMessageNotReadable] {}", e.getMessage());
+            return ResponseEntity
+                    .status(HttpStatus.BAD_REQUEST)
+                    .body(CommonResponse.error(4006, "planDate 형식이 올바르지 않습니다."));
+        }
+
+        log.warn("[HttpMessageNotReadable] {}", e.getMessage());
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(CommonResponse.error(4001, "요청 값이 유효하지 않습니다."));
     }
 
     @ExceptionHandler(AuthenticationException.class)

--- a/src/main/java/com/bready/server/plan/controller/PlanController.java
+++ b/src/main/java/com/bready/server/plan/controller/PlanController.java
@@ -124,7 +124,7 @@ public class PlanController {
     }
 
 
-    @DeleteMapping("/{planId")
+    @DeleteMapping("/{planId}")
     @ResponseStatus(HttpStatus.OK)
     @Operation(
             summary = "플랜 삭제",

--- a/src/main/java/com/bready/server/plan/controller/PlanController.java
+++ b/src/main/java/com/bready/server/plan/controller/PlanController.java
@@ -98,4 +98,27 @@ public class PlanController {
     ) {
         return CommonResponse.success(planService.getPlanDetail(userId, planId));
     }
+
+    @GetMapping
+    @ResponseStatus(HttpStatus.OK)
+    @Operation(
+            summary = "내 플랜 목록 조회",
+            description = "인증된 사용자의 플랜 목록 조회"
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "목록 조회 성공",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "401", description = "인증 필요",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "500", description = "서버 오류",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+    })
+    public CommonResponse<PlanListResponse> getMyPlans(
+            @CurrentUser Long userId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size,
+            @RequestParam(defaultValue = "desc") String order
+    ) {
+        return CommonResponse.success(planService.getMyPlans(userId, page, size, order));
+    }
 }

--- a/src/main/java/com/bready/server/plan/controller/PlanController.java
+++ b/src/main/java/com/bready/server/plan/controller/PlanController.java
@@ -62,7 +62,7 @@ public class PlanController {
             @ApiResponse(responseCode = "401", description = "인증 필요",
                     content = @Content(schema = @Schema(implementation = CommonResponse.class))),
             @ApiResponse(responseCode = "403", description = "플랜 수정 권한 없음",
-                    content = @Content(schema = @Schema(implementation = CommonResponse.class)))
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
             @ApiResponse(responseCode = "404", description = "플랜 없음",
                     content = @Content(schema = @Schema(implementation = CommonResponse.class))),
             @ApiResponse(responseCode = "500", description = "플랜 수정 실패 (서버 오류)",

--- a/src/main/java/com/bready/server/plan/controller/PlanController.java
+++ b/src/main/java/com/bready/server/plan/controller/PlanController.java
@@ -99,6 +99,7 @@ public class PlanController {
         return CommonResponse.success(planService.getPlanDetail(userId, planId));
     }
 
+
     @GetMapping
     @ResponseStatus(HttpStatus.OK)
     @Operation(
@@ -121,4 +122,28 @@ public class PlanController {
     ) {
         return CommonResponse.success(planService.getMyPlans(userId, page, size, order));
     }
+
+
+    @DeleteMapping("/{planId")
+    @ResponseStatus(HttpStatus.OK)
+    @Operation(
+            summary = "플랜 삭제",
+            description = "인증된 사용자가 본인의 플랜 삭제 (soft delete)"
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "플랜 삭제 성공",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "401", description = "인증 필요",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "403", description = "플랜 삭제 권한 없음",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "404", description = "플랜 없음",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "500", description = "서버 오류",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class)))
+    })
+    public CommonResponse<PlanDeleteResponse> deletePlan(@CurrentUser Long userId, @PathVariable Long planId) {
+        return CommonResponse.success(planService.deletePlan(userId, planId));
+    }
+
 }

--- a/src/main/java/com/bready/server/plan/controller/PlanController.java
+++ b/src/main/java/com/bready/server/plan/controller/PlanController.java
@@ -4,6 +4,8 @@ import com.bready.server.global.auth.CurrentUser;
 import com.bready.server.global.response.CommonResponse;
 import com.bready.server.plan.dto.PlanCreateRequest;
 import com.bready.server.plan.dto.PlanCreateResponse;
+import com.bready.server.plan.dto.PlanUpdateRequest;
+import com.bready.server.plan.dto.PlanUpdateResponse;
 import com.bready.server.plan.service.PlanService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -44,4 +46,34 @@ public class PlanController {
     ) {
         return CommonResponse.success(planService.createPlan(userId, request));
     }
+
+
+    @PostMapping("/{planId}")
+    @ResponseStatus(HttpStatus.OK)
+    @Operation(
+            summary = "플랜 수정",
+            description = "플랜의 제목, 날짜, 지역을 수정합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "플랜 수정 성공",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "400", description = "요청 값 오류 (누락/형식오류)",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "401", description = "인증 필요",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "403", description = "플랜 수정 권한 없음",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class)))
+            @ApiResponse(responseCode = "404", description = "플랜 없음",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "500", description = "플랜 수정 실패 (서버 오류)",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class)))
+    })
+    public CommonResponse<PlanUpdateResponse> updatePlan(
+            @CurrentUser Long userId,
+            @PathVariable Long planId,
+            @Valid @RequestBody PlanUpdateRequest request
+    ) {
+        return CommonResponse.success(planService.updatePlan(userId, planId, request));
+    }
+
 }

--- a/src/main/java/com/bready/server/plan/controller/PlanController.java
+++ b/src/main/java/com/bready/server/plan/controller/PlanController.java
@@ -1,11 +1,47 @@
 package com.bready.server.plan.controller;
 
+import com.bready.server.global.auth.CurrentUser;
+import com.bready.server.global.response.CommonResponse;
+import com.bready.server.plan.dto.PlanCreateRequest;
+import com.bready.server.plan.dto.PlanCreateResponse;
+import com.bready.server.plan.service.PlanService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/v1/plans")
 @RequiredArgsConstructor
 public class PlanController {
+
+    private final PlanService planService;
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    @Operation(
+            summary = "플랜 생성",
+            description = "인증된 사용자가 새로운 플랜을 생성합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "플랜 생성 성공",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "400", description = "요청 값 오류 (누락/형식오류)",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "401", description = "인증 필요",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "500", description = "플랜 생성 실패 (서버 오류)",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class)))
+    })
+    public CommonResponse<PlanCreateResponse> createPlan(
+            @CurrentUser Long userId,
+            @Valid @RequestBody PlanCreateRequest request
+    ) {
+        return CommonResponse.success(planService.createPlan(userId, request));
+    }
 }

--- a/src/main/java/com/bready/server/plan/controller/PlanController.java
+++ b/src/main/java/com/bready/server/plan/controller/PlanController.java
@@ -45,7 +45,7 @@ public class PlanController {
     }
 
 
-    @PostMapping("/{planId}")
+    @PatchMapping("/{planId}")
     @ResponseStatus(HttpStatus.OK)
     @Operation(
             summary = "플랜 수정",

--- a/src/main/java/com/bready/server/plan/controller/PlanController.java
+++ b/src/main/java/com/bready/server/plan/controller/PlanController.java
@@ -2,10 +2,7 @@ package com.bready.server.plan.controller;
 
 import com.bready.server.global.auth.CurrentUser;
 import com.bready.server.global.response.CommonResponse;
-import com.bready.server.plan.dto.PlanCreateRequest;
-import com.bready.server.plan.dto.PlanCreateResponse;
-import com.bready.server.plan.dto.PlanUpdateRequest;
-import com.bready.server.plan.dto.PlanUpdateResponse;
+import com.bready.server.plan.dto.*;
 import com.bready.server.plan.service.PlanService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -76,4 +73,29 @@ public class PlanController {
         return CommonResponse.success(planService.updatePlan(userId, planId, request));
     }
 
+
+    @GetMapping("/{planId}")
+    @ResponseStatus(HttpStatus.OK)
+    @Operation(
+            summary = "플랜 상세 조회",
+            description = "플랜 기본 정보 조회 (카테고리/장소 추후 확장)"
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "플랜 조회 성공",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "401", description = "인증 필요",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "403", description = "플랜 조회 권한 없음",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "404", description = "플랜 없음",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "500", description = "플랜 수정 실패 (서버 오류)",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class)))
+    })
+    public CommonResponse<PlanDetailResponse> getPlanDetail(
+            @CurrentUser Long userId,
+            @PathVariable Long planId
+    ) {
+        return CommonResponse.success(planService.getPlanDetail(userId, planId));
+    }
 }

--- a/src/main/java/com/bready/server/plan/controller/PlanController.java
+++ b/src/main/java/com/bready/server/plan/controller/PlanController.java
@@ -89,7 +89,7 @@ public class PlanController {
                     content = @Content(schema = @Schema(implementation = CommonResponse.class))),
             @ApiResponse(responseCode = "404", description = "플랜 없음",
                     content = @Content(schema = @Schema(implementation = CommonResponse.class))),
-            @ApiResponse(responseCode = "500", description = "플랜 수정 실패 (서버 오류)",
+            @ApiResponse(responseCode = "500", description = "플랜 조회 실패 (서버 오류)",
                     content = @Content(schema = @Schema(implementation = CommonResponse.class)))
     })
     public CommonResponse<PlanDetailResponse> getPlanDetail(

--- a/src/main/java/com/bready/server/plan/controller/PlanController.java
+++ b/src/main/java/com/bready/server/plan/controller/PlanController.java
@@ -118,7 +118,7 @@ public class PlanController {
             @CurrentUser Long userId,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size,
-            @RequestParam(defaultValue = "desc") String order
+            @RequestParam(defaultValue = "DESC") SortDirection order
     ) {
         return CommonResponse.success(planService.getMyPlans(userId, page, size, order));
     }

--- a/src/main/java/com/bready/server/plan/domain/Plan.java
+++ b/src/main/java/com/bready/server/plan/domain/Plan.java
@@ -41,4 +41,10 @@ public class Plan extends BaseEntity {
         plan.status = "ACTIVE";
         return plan;
     }
+
+    public void update(String title, LocalDate planDate, String region) {
+        this.title = title;
+        this.planDate = planDate;
+        this.region = region;
+    }
 }

--- a/src/main/java/com/bready/server/plan/domain/Plan.java
+++ b/src/main/java/com/bready/server/plan/domain/Plan.java
@@ -31,4 +31,14 @@ public class Plan extends BaseEntity {
 
     @Column(nullable = false)
     private String status;
+
+    public static Plan create(Long ownerId, String title, LocalDate planDate, String region) {
+        Plan plan = new Plan();
+        plan.ownerId = ownerId;
+        plan.title = title;
+        plan.planDate = planDate;
+        plan.region = region;
+        plan.status = "ACTIVE";
+        return plan;
+    }
 }

--- a/src/main/java/com/bready/server/plan/dto/PageInfo.java
+++ b/src/main/java/com/bready/server/plan/dto/PageInfo.java
@@ -1,0 +1,16 @@
+package com.bready.server.plan.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+// PlanList 페이지네이션용
+public class PageInfo {
+
+    private int page;                 // 현재 페이지 번호
+    private int size;                 // 한 페이지 당 몇개
+    private long totalElements;       // 전체 플랜 수
+    private int totalPages;           // 전체 페이지 수
+
+}

--- a/src/main/java/com/bready/server/plan/dto/PlanCreateRequest.java
+++ b/src/main/java/com/bready/server/plan/dto/PlanCreateRequest.java
@@ -1,0 +1,20 @@
+package com.bready.server.plan.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+public class PlanCreateRequest {
+
+    @NotBlank(message = "플랜 제목을 입력해주세요.")
+    private String title;
+
+    @NotNull(message = "플랜 날짜를 선택해주세요.")
+    private LocalDate planDate;
+
+    @NotBlank(message = "지역 정보를 입력해주세요.")
+    private String region;
+}

--- a/src/main/java/com/bready/server/plan/dto/PlanCreateResponse.java
+++ b/src/main/java/com/bready/server/plan/dto/PlanCreateResponse.java
@@ -1,0 +1,15 @@
+package com.bready.server.plan.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class PlanCreateResponse {
+
+    private Long planId;
+    private LocalDateTime createdAt;
+
+}

--- a/src/main/java/com/bready/server/plan/dto/PlanDeleteResponse.java
+++ b/src/main/java/com/bready/server/plan/dto/PlanDeleteResponse.java
@@ -1,0 +1,15 @@
+package com.bready.server.plan.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class PlanDeleteResponse {
+
+    private Long planId;
+    private LocalDateTime deletedAt;
+
+}

--- a/src/main/java/com/bready/server/plan/dto/PlanDetailResponse.java
+++ b/src/main/java/com/bready/server/plan/dto/PlanDetailResponse.java
@@ -1,0 +1,16 @@
+package com.bready.server.plan.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class PlanDetailResponse {
+
+    private PlanDto plan;
+    // TODO : 장소, 카테고리 등 연결
+
+}

--- a/src/main/java/com/bready/server/plan/dto/PlanDto.java
+++ b/src/main/java/com/bready/server/plan/dto/PlanDto.java
@@ -1,0 +1,21 @@
+package com.bready.server.plan.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class PlanDto {
+
+    private Long planId;
+    private String title;
+    private LocalDate planDate;
+    private String region;
+    private String status;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+}

--- a/src/main/java/com/bready/server/plan/dto/PlanListItemDto.java
+++ b/src/main/java/com/bready/server/plan/dto/PlanListItemDto.java
@@ -1,0 +1,21 @@
+package com.bready.server.plan.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class PlanListItemDto {
+
+    private Long planId;
+    private String title;
+    private LocalDate planDate;
+    private String region;
+    private String status;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+}

--- a/src/main/java/com/bready/server/plan/dto/PlanListResponse.java
+++ b/src/main/java/com/bready/server/plan/dto/PlanListResponse.java
@@ -1,0 +1,15 @@
+package com.bready.server.plan.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class PlanListResponse {
+
+    private List<PlanListItemDto> items;
+    private PageInfo pageInfo;
+
+}

--- a/src/main/java/com/bready/server/plan/dto/PlanUpdateRequest.java
+++ b/src/main/java/com/bready/server/plan/dto/PlanUpdateRequest.java
@@ -1,0 +1,21 @@
+package com.bready.server.plan.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+public class PlanUpdateRequest {
+
+    @NotBlank(message = "플랜 제목을 입력해주세요.")
+    private String title;
+
+    @NotNull(message = "플랜 날짜를 선택해주세요.")
+    private LocalDate planDate;
+
+    @NotBlank(message = "지역 정보를 입력해주세요.")
+    private String region;
+
+}

--- a/src/main/java/com/bready/server/plan/dto/PlanUpdateResponse.java
+++ b/src/main/java/com/bready/server/plan/dto/PlanUpdateResponse.java
@@ -1,0 +1,15 @@
+package com.bready.server.plan.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class PlanUpdateResponse {
+
+    private Long planId;
+    private LocalDateTime updatedAt;
+
+}

--- a/src/main/java/com/bready/server/plan/dto/SortDirection.java
+++ b/src/main/java/com/bready/server/plan/dto/SortDirection.java
@@ -1,0 +1,5 @@
+package com.bready.server.plan.dto;
+
+public enum SortDirection {
+    ASC, DESC
+}

--- a/src/main/java/com/bready/server/plan/repository/PlanRepository.java
+++ b/src/main/java/com/bready/server/plan/repository/PlanRepository.java
@@ -11,8 +11,6 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
-import java.time.LocalDateTime;
-
 public interface PlanRepository extends JpaRepository<Plan, Long> {
 
     Page<Plan> findAllByOwnerIdAndDeletedAtIsNull(Long ownerId, Pageable pageable);
@@ -59,4 +57,7 @@ public interface PlanRepository extends JpaRepository<Plan, Long> {
         where p.ownerId = :ownerId
     """)
     long countByOwnerId(@Param("ownerId") Long ownerId);
+
+    Optional<Plan> findByIdAndDeletedAtIsNull(Long id);
+
 }

--- a/src/main/java/com/bready/server/plan/repository/PlanRepository.java
+++ b/src/main/java/com/bready/server/plan/repository/PlanRepository.java
@@ -1,7 +1,14 @@
 package com.bready.server.plan.repository;
 
 import com.bready.server.plan.domain.Plan;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDateTime;
+
 public interface PlanRepository extends JpaRepository<Plan, Long> {
+
+    Page<Plan> findAllByOwnerIdAndDeletedAtIsNull(Long ownerId, Pageable pageable);
+
 }

--- a/src/main/java/com/bready/server/plan/service/PlanService.java
+++ b/src/main/java/com/bready/server/plan/service/PlanService.java
@@ -112,4 +112,29 @@ public class PlanService {
                 .pageInfo(pageInfo)
                 .build();
     }
+
+    @Transactional
+    public PlanDeleteResponse deletePlan(Long userId, Long planId) {
+
+        Plan plan = planRepository.findById(planId)
+                .orElseThrow(() -> new ApplicationException(PlanErrorCase.PLAN_NOT_FOUND));
+
+        if (!plan.getOwnerId().equals(userId)) {
+            throw new ApplicationException(PlanErrorCase.PLAN_ACCESS_DENIED);
+        }
+
+        if (plan.isDeleted()) {
+            return PlanDeleteResponse.builder()
+                    .planId(plan.getId())
+                    .deletedAt(plan.getDeletedAt())
+                    .build();
+        }
+
+        plan.softDelete();
+
+        return PlanDeleteResponse.builder()
+                .planId(plan.getId())
+                .deletedAt(plan.getDeletedAt())
+                .build();
+    }
 }

--- a/src/main/java/com/bready/server/plan/service/PlanService.java
+++ b/src/main/java/com/bready/server/plan/service/PlanService.java
@@ -2,10 +2,7 @@ package com.bready.server.plan.service;
 
 import com.bready.server.global.exception.ApplicationException;
 import com.bready.server.plan.domain.Plan;
-import com.bready.server.plan.dto.PlanCreateRequest;
-import com.bready.server.plan.dto.PlanCreateResponse;
-import com.bready.server.plan.dto.PlanUpdateRequest;
-import com.bready.server.plan.dto.PlanUpdateResponse;
+import com.bready.server.plan.dto.*;
 import com.bready.server.plan.exception.PlanErrorCase;
 import com.bready.server.plan.repository.PlanRepository;
 import lombok.RequiredArgsConstructor;
@@ -48,6 +45,32 @@ public class PlanService {
         return PlanUpdateResponse.builder()
                 .planId(plan.getId())
                 .updatedAt(plan.getUpdatedAt())
+                .build();
+    }
+
+    @Transactional(readOnly = true)
+    public PlanDetailResponse getPlanDetail(Long userId, Long planId) {
+
+        Plan plan = planRepository.findById(planId)
+                .orElseThrow(() -> new ApplicationException(PlanErrorCase.PLAN_NOT_FOUND));
+
+        // TODO : 플랜 공유 기능 도입 시 소유자 외에도 조회 권한 허용
+        if (!plan.getOwnerId().equals(userId)) {
+            throw new ApplicationException(PlanErrorCase.PLAN_ACCESS_DENIED);
+        }
+
+        PlanDto planDto = PlanDto.builder()
+                .planId(plan.getId())
+                .title(plan.getTitle())
+                .planDate(plan.getPlanDate())
+                .region(plan.getRegion())
+                .status(plan.getStatus())
+                .createdAt(plan.getCreatedAt())
+                .updatedAt(plan.getUpdatedAt())
+                .build();
+
+        return PlanDetailResponse.builder()
+                .plan(planDto)
                 .build();
     }
 }

--- a/src/main/java/com/bready/server/plan/service/PlanService.java
+++ b/src/main/java/com/bready/server/plan/service/PlanService.java
@@ -1,9 +1,29 @@
 package com.bready.server.plan.service;
 
+import com.bready.server.plan.domain.Plan;
+import com.bready.server.plan.dto.PlanCreateRequest;
+import com.bready.server.plan.dto.PlanCreateResponse;
+import com.bready.server.plan.repository.PlanRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class PlanService {
+
+    private final PlanRepository planRepository;
+
+    @Transactional
+    public PlanCreateResponse createPlan(Long userId, PlanCreateRequest request) {
+
+        Plan plan = Plan.create(userId, request.getTitle(), request.getPlanDate(), request.getRegion());
+
+        Plan saved = planRepository.save(plan);
+
+        return PlanCreateResponse.builder()
+                .planId(saved.getId())
+                .createdAt(saved.getCreatedAt())
+                .build();
+    }
 }

--- a/src/main/java/com/bready/server/plan/service/PlanService.java
+++ b/src/main/java/com/bready/server/plan/service/PlanService.java
@@ -36,7 +36,7 @@ public class PlanService {
 
     @Transactional
     public PlanUpdateResponse updatePlan(Long userId, Long planId, PlanUpdateRequest request) {
-        Plan plan = planRepository.findById(planId)
+        Plan plan = planRepository.findByIdAndDeletedAtIsNull(planId)
                 .orElseThrow(() -> new ApplicationException(PlanErrorCase.PLAN_NOT_FOUND));
 
         if (!plan.getOwnerId().equals(userId)) {
@@ -57,7 +57,7 @@ public class PlanService {
     @Transactional(readOnly = true)
     public PlanDetailResponse getPlanDetail(Long userId, Long planId) {
 
-        Plan plan = planRepository.findById(planId)
+        Plan plan = planRepository.findByIdAndDeletedAtIsNull(planId)
                 .orElseThrow(() -> new ApplicationException(PlanErrorCase.PLAN_NOT_FOUND));
 
         // TODO : 플랜 공유 기능 도입 시 소유자 외에도 조회 권한 허용
@@ -116,18 +116,11 @@ public class PlanService {
     @Transactional
     public PlanDeleteResponse deletePlan(Long userId, Long planId) {
 
-        Plan plan = planRepository.findById(planId)
+        Plan plan = planRepository.findByIdAndDeletedAtIsNull(planId)
                 .orElseThrow(() -> new ApplicationException(PlanErrorCase.PLAN_NOT_FOUND));
 
         if (!plan.getOwnerId().equals(userId)) {
             throw new ApplicationException(PlanErrorCase.PLAN_ACCESS_DENIED);
-        }
-
-        if (plan.isDeleted()) {
-            return PlanDeleteResponse.builder()
-                    .planId(plan.getId())
-                    .deletedAt(plan.getDeletedAt())
-                    .build();
         }
 
         plan.softDelete();

--- a/src/main/java/com/bready/server/plan/service/PlanService.java
+++ b/src/main/java/com/bready/server/plan/service/PlanService.java
@@ -1,8 +1,12 @@
 package com.bready.server.plan.service;
 
+import com.bready.server.global.exception.ApplicationException;
 import com.bready.server.plan.domain.Plan;
 import com.bready.server.plan.dto.PlanCreateRequest;
 import com.bready.server.plan.dto.PlanCreateResponse;
+import com.bready.server.plan.dto.PlanUpdateRequest;
+import com.bready.server.plan.dto.PlanUpdateResponse;
+import com.bready.server.plan.exception.PlanErrorCase;
 import com.bready.server.plan.repository.PlanRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -24,6 +28,26 @@ public class PlanService {
         return PlanCreateResponse.builder()
                 .planId(saved.getId())
                 .createdAt(saved.getCreatedAt())
+                .build();
+    }
+
+    @Transactional
+    public PlanUpdateResponse updatePlan(Long userId, Long planId, PlanUpdateRequest request) {
+        Plan plan = planRepository.findById(planId)
+                .orElseThrow(() -> new ApplicationException(PlanErrorCase.PLAN_NOT_FOUND));
+
+        if (!plan.getOwnerId().equals(userId)) {
+            throw new ApplicationException(PlanErrorCase.PLAN_ACCESS_DENIED);
+        }
+
+        plan.update(
+                request.getTitle(),
+                request.getPlanDate(),
+                request.getRegion());
+
+        return PlanUpdateResponse.builder()
+                .planId(plan.getId())
+                .updatedAt(plan.getUpdatedAt())
                 .build();
     }
 }

--- a/src/main/java/com/bready/server/plan/service/PlanService.java
+++ b/src/main/java/com/bready/server/plan/service/PlanService.java
@@ -84,7 +84,7 @@ public class PlanService {
     public PlanListResponse getMyPlans(Long userId, int page, int size, String order) {
         Sort.Direction direction = "asc".equalsIgnoreCase(order) ? Sort.Direction.ASC : Sort.Direction.DESC;
 
-        Pageable pageable = PageRequest.of(page, size, Sort.by(direction, "planDate"));
+        Pageable pageable = PageRequest.of(page, size, Sort.by(direction, "planDate").and(Sort.by(Sort.Direction.DESC, "createdAt")));
 
         Page<Plan> result = planRepository.findAllByOwnerIdAndDeletedAtIsNull(userId, pageable);
 

--- a/src/main/java/com/bready/server/plan/service/PlanService.java
+++ b/src/main/java/com/bready/server/plan/service/PlanService.java
@@ -81,8 +81,8 @@ public class PlanService {
     }
 
     @Transactional(readOnly = true)
-    public PlanListResponse getMyPlans(Long userId, int page, int size, String order) {
-        Sort.Direction direction = "asc".equalsIgnoreCase(order) ? Sort.Direction.ASC : Sort.Direction.DESC;
+    public PlanListResponse getMyPlans(Long userId, int page, int size, SortDirection order) {
+        Sort.Direction direction = (order == SortDirection.ASC) ? Sort.Direction.ASC : Sort.Direction.DESC;
 
         Pageable pageable = PageRequest.of(page, size, Sort.by(direction, "planDate").and(Sort.by(Sort.Direction.DESC, "createdAt")));
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #49 

## 📝 작업 내용

- 플랜 생성 / 수정 / 삭제 / 상세 조회 / 목록 조회 API 구현
- BaseEntity의 deleteAt을 활용한 soft delete 적용
- 플랜 목록 조회 페이지네이션 / 정렬 로직 구현
   기본 정렬 : `planDate` 기준 미래 일정 우선
   동일 날짜일 경우 `createdAt` 기준 보조 정렬


## 🖼️ 스크린샷 (선택)
### 플랜 생성 
<img width="623" height="344" alt="image" src="https://github.com/user-attachments/assets/c03276cc-cfd7-4b82-b682-6e89cd528626" />

### 플랜 수정
<img width="616" height="358" alt="image" src="https://github.com/user-attachments/assets/ecc2efd6-23a6-4ce1-b23b-ffb43054606c" />

### 플랜 상세 조회
<img width="524" height="442" alt="image" src="https://github.com/user-attachments/assets/f8eb1da8-f791-444e-bffd-8f43128caf59" />

### 플랜 삭제
<img width="571" height="351" alt="image" src="https://github.com/user-attachments/assets/d322b6f3-c1ff-41f2-8861-f828516844ae" />

### 플랜 목록 조회
<img width="749" height="697" alt="image" src="https://github.com/user-attachments/assets/465732d6-ea4a-45dc-9a88-8d71a216c23e" />


## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특히 봐주었으면 하는 부분이 있다면 작성해주세요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# 릴리스 노트

* **새로운 기능**
  * 플랜 생성/수정/삭제/상세/목록 REST API 추가
  * 플랜 목록 페이징 및 정렬 지원
  * 플랜 관련 요청·응답 포맷(생성/수정/상세/목록, 페이지정보 및 리스트/아이템 DTO) 추가

* **보안**
  * 모든 요청에 인증을 요구하도록 보안 정책 강화

* **버그 수정**
  * 읽을 수 없는 요청 본문 처리 개선(플랜 날짜 형식 오류에 대한 상세한 400 응답)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->