### PR TITLE
[test] JOIN 기반 통계 API 부하 테스트 및 병목 분석

### DIFF
--- a/performance-test/k6/scripts/plan_stats_join_p95.js
+++ b/performance-test/k6/scripts/plan_stats_join_p95.js
@@ -1,0 +1,41 @@
+import http from "k6/http";
+import { check, sleep } from "k6";
+
+const BASE_URL = __ENV.BASE_URL || "http://host.docker.internal:8080";
+const TOKEN = __ENV.ACCESS_TOKEN;
+
+export const options = {
+    scenarios: {
+        join_load_test: {
+            executor: "ramping-vus",
+            stages: [
+                { duration: "20s", target: 20 },
+                { duration: "40s", target: 50 },
+                { duration: "40s", target: 80 },
+                { duration: "20s", target: 0 },
+            ],
+        },
+    },
+    thresholds: {
+        http_req_failed: ["rate<0.01"],
+        http_req_duration: ["p(95)<600"],
+    },
+};
+
+export default function () {
+    const res = http.get(
+        `${BASE_URL}/api/v1/stats/plans/join?period=WEEK&limit=10`,
+        {
+            headers: {
+                Authorization: `Bearer ${TOKEN}`,
+            },
+            timeout: "10s",
+        }
+    );
+
+    check(res, {
+        "JOIN 200": (r) => r.status === 200,
+    });
+
+    sleep(1);
+}

--- a/performance-test/k6/scripts/plan_stats_p95.js
+++ b/performance-test/k6/scripts/plan_stats_p95.js
@@ -2,7 +2,7 @@ import http from "k6/http";
 import { check, sleep } from "k6";
 
 
-const BASE_URL = __ENV.BASE_URL || "http://localhost:8080";
+const BASE_URL = __ENV.BASE_URL || "http://host.docker.internal:8080";
 
 export const options = {
 

--- a/performance-test/k6/scripts/plan_stats_p95.js
+++ b/performance-test/k6/scripts/plan_stats_p95.js
@@ -1,0 +1,63 @@
+import http from "k6/http";
+import { check, sleep } from "k6";
+
+
+const BASE_URL = __ENV.BASE_URL || "http://localhost:8080";
+
+export const options = {
+
+    scenarios: {
+        stats_load_test: {
+            executor: "ramping-vus",
+
+            stages: [
+                { duration: "20s", target: 20 }, // 워밍업
+                { duration: "40s", target: 50 }, // 중간 부하
+                { duration: "40s", target: 80 }, // 실제 압박
+                { duration: "20s", target: 0 },
+            ],
+
+            gracefulRampDown: "10s",
+        },
+    },
+
+    thresholds: {
+
+        // 실패율 1% 이하
+        http_req_failed: ["rate<0.01"],
+
+        // p95가 600ms 넘으면 FAIL
+        http_req_duration: ["p(95)<600"],
+
+    },
+};
+
+export default function () {
+    const params = {
+        headers: {
+            "Content-Type": "application/json",
+        },
+        timeout: "10s",
+    };
+
+    const joinRes = http.get(
+        `${BASE_URL}/api/v1/plans/stats?period=WEEK&limit=10&mode=join`,
+        params
+    );
+
+    check(joinRes, {
+        "JOIN status 200": (r) => r.status === 200,
+    });
+
+
+    const matRes = http.get(
+        `${BASE_URL}/api/v1/plans/stats?period=WEEK&limit=10&mode=mat`,
+        params
+    );
+
+    check(matRes, {
+        "MAT status 200": (r) => r.status === 200,
+    });
+
+    sleep(1);
+}

--- a/performance-test/k6/scripts/plan_stats_p95.js
+++ b/performance-test/k6/scripts/plan_stats_p95.js
@@ -36,12 +36,13 @@ export default function () {
     const params = {
         headers: {
             "Content-Type": "application/json",
+            "Authorization": `Bearer ${__ENV.ACCESS_TOKEN}`,
         },
         timeout: "10s",
     };
 
     const joinRes = http.get(
-        `${BASE_URL}/api/v1/plans/stats?period=WEEK&limit=10&mode=join`,
+        `${BASE_URL}/api/v1/stats/plans?period=WEEK&limit=10`,
         params
     );
 
@@ -49,9 +50,12 @@ export default function () {
         "JOIN status 200": (r) => r.status === 200,
     });
 
+    if (joinRes.status !== 200) {
+        console.log(`JOIN FAILED: ${joinRes.status}`);
+    }
 
     const matRes = http.get(
-        `${BASE_URL}/api/v1/plans/stats?period=WEEK&limit=10&mode=mat`,
+        `${BASE_URL}/api/v1/stats/plans/materialized?period=WEEK&limit=10`,
         params
     );
 

--- a/performance-test/sql/dummy-data-500k.sql
+++ b/performance-test/sql/dummy-data-500k.sql
@@ -101,3 +101,9 @@ FROM decisions d
 WHERE d.decision_type = 'SWITCH';
 
 SET FOREIGN_KEY_CHECKS = 1;
+
+
+ANALYZE TABLE triggers;
+ANALYZE TABLE decisions;
+ANALYZE TABLE switch_logs;
+ANALYZE TABLE plans;

--- a/performance-test/sql/dummy-data-500k.sql
+++ b/performance-test/sql/dummy-data-500k.sql
@@ -1,0 +1,103 @@
+SET FOREIGN_KEY_CHECKS = 0;
+
+/* 숫자 테이블 (0 ~ 99,999) */
+
+DROP TABLE IF EXISTS numbers;
+
+CREATE TABLE numbers AS
+SELECT
+    a.n
+        + b.n * 10
+        + c.n * 100
+        + d.n * 1000
+        + e.n * 10000 AS num
+FROM
+    (SELECT 0 n UNION ALL SELECT 1 UNION ALL SELECT 2 UNION ALL SELECT 3 UNION ALL SELECT 4
+     UNION ALL SELECT 5 UNION ALL SELECT 6 UNION ALL SELECT 7 UNION ALL SELECT 8 UNION ALL SELECT 9) a,
+    (SELECT 0 n UNION ALL SELECT 1 UNION ALL SELECT 2 UNION ALL SELECT 3 UNION ALL SELECT 4
+     UNION ALL SELECT 5 UNION ALL SELECT 6 UNION ALL SELECT 7 UNION ALL SELECT 8 UNION ALL SELECT 9) b,
+    (SELECT 0 n UNION ALL SELECT 1 UNION ALL SELECT 2 UNION ALL SELECT 3 UNION ALL SELECT 4
+     UNION ALL SELECT 5 UNION ALL SELECT 6 UNION ALL SELECT 7 UNION ALL SELECT 8 UNION ALL SELECT 9) c,
+    (SELECT 0 n UNION ALL SELECT 1 UNION ALL SELECT 2 UNION ALL SELECT 3 UNION ALL SELECT 4
+     UNION ALL SELECT 5 UNION ALL SELECT 6 UNION ALL SELECT 7 UNION ALL SELECT 8 UNION ALL SELECT 9) d,
+    (SELECT 0 n UNION ALL SELECT 1 UNION ALL SELECT 2 UNION ALL SELECT 3 UNION ALL SELECT 4
+     UNION ALL SELECT 5 UNION ALL SELECT 6 UNION ALL SELECT 7 UNION ALL SELECT 8 UNION ALL SELECT 9) e;
+
+/* Plan 1,000개 생성 */
+INSERT INTO plans (owner_id, title, plan_date, region, status, created_at, updated_at)
+SELECT
+    1,
+    CONCAT('plan-', num),
+    CURDATE() - INTERVAL (num % 30) DAY,
+    'SEOUL',
+    'ACTIVE',
+    NOW(),
+    NOW()
+FROM numbers
+    LIMIT 1000;
+
+/* Trigger 500,000개 생성
+   - plan_id 랜덤 매핑
+   - trigger_type 랜덤 분포 */
+INSERT INTO triggers (
+    plan_id,
+    category_id,
+    candidate_id,
+    trigger_type,
+    occurred_at,
+    created_at,
+    updated_at
+)
+SELECT
+    FLOOR(1 + RAND() * 1000),      -- plan_id
+    1,                             -- category_id
+    1,                             -- candidate_id
+    ELT(
+            FLOOR(1 + RAND() * 5),
+            'WEATHER_BAD',
+            'WAITING_LONG',
+            'CLOSED',
+            'FATIGUE',
+            'DISTANCE_FAR'
+    ),
+    NOW() - INTERVAL FLOOR(RAND() * 30) DAY,
+    NOW(),
+    NOW()
+FROM numbers n1
+    JOIN numbers n2
+    LIMIT 500000;
+
+/* Decision 생성 (Trigger 1:1) - SWITCH 약 30%, KEEP 약 70% */
+INSERT INTO decisions (
+    trigger_id,
+    decision_type,
+    decided_at,
+    created_at,
+    updated_at
+)
+SELECT
+    t.id,
+    IF(RAND() < 0.3, 'SWITCH', 'KEEP'),
+    NOW(),
+    NOW(),
+    NOW()
+FROM triggers t;
+
+/* SwitchLog 생성 (SWITCH만) */
+INSERT INTO switch_logs (
+    decision_id,
+    from_candidate_id,
+    to_candidate_id,
+    created_at,
+    updated_at
+)
+SELECT
+    d.id,
+    1,
+    2,
+    NOW(),
+    NOW()
+FROM decisions d
+WHERE d.decision_type = 'SWITCH';
+
+SET FOREIGN_KEY_CHECKS = 1;

--- a/performance-test/sql/dummy-data-500k.sql
+++ b/performance-test/sql/dummy-data-500k.sql
@@ -55,10 +55,10 @@ SELECT
     ELT(
             FLOOR(1 + RAND() * 5),
             'WEATHER_BAD',
-            'WAITING_LONG',
-            'CLOSED',
+            'WAITING_TOO_LONG',
+            'PLACE_CLOSED',
             'FATIGUE',
-            'DISTANCE_FAR'
+            'DISTANCE_TOO_FAR'
     ),
     NOW() - INTERVAL FLOOR(RAND() * 30) DAY,
     NOW(),

--- a/src/main/java/com/bready/server/stats/controller/PlanStatsController.java
+++ b/src/main/java/com/bready/server/stats/controller/PlanStatsController.java
@@ -4,15 +4,9 @@ import com.bready.server.global.auth.CurrentUser;
 import com.bready.server.global.response.CommonResponse;
 import com.bready.server.stats.domain.StatsPeriod;
 import com.bready.server.stats.dto.PlanStatsResponse;
-import com.bready.server.stats.service.PlanListStatsService;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import com.bready.server.stats.service.PlanStatsJoinService;
+import com.bready.server.stats.service.PlanStatsMaterializedService;
 import jakarta.validation.constraints.Max;
-import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
 import org.springframework.validation.annotation.Validated;
@@ -20,6 +14,8 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import jakarta.validation.constraints.NotNull;
+
 
 @RestController
 @RequiredArgsConstructor
@@ -27,8 +23,10 @@ import org.springframework.web.bind.annotation.RestController;
 @Validated
 public class PlanStatsController {
 
-    private final PlanListStatsService planListStatsService;
+    private final PlanStatsJoinService joinService;
+    private final PlanStatsMaterializedService materializedService;
 
+    /*
     @GetMapping("/plans")
     @Operation(
             summary = "플랜별 통계 목록 조회",
@@ -50,6 +48,33 @@ public class PlanStatsController {
             @Parameter(description = "목록 개수 (기본 20, 최대 50)", example = "20")
             @RequestParam(required = false) @Positive @Max(50) Integer limit
     ) {
-        return CommonResponse.success(planListStatsService.getPlanStats(ownerId, period, limit));
+        return CommonResponse.success(planStatsJoinService.getPlanStats(ownerId, period, limit));
+    }
+     */
+
+    // JOIN 기반 조회
+    @GetMapping("/plans/join")
+    public CommonResponse<PlanStatsResponse> getJoinStats(
+            @CurrentUser Long ownerId,
+            @RequestParam @NotNull StatsPeriod period,
+            @RequestParam(required = false) @Positive @Max(50) Integer limit
+    ) {
+
+        return CommonResponse.success(
+                joinService.getStats(ownerId, period, limit)
+        );
+    }
+
+    // Materialized 조회
+    @GetMapping("/plans/materialized")
+    public CommonResponse<PlanStatsResponse> getMaterializedStats(
+            @CurrentUser Long ownerId,
+            @RequestParam @NotNull StatsPeriod period,
+            @RequestParam(required = false) @Positive @Max(50) Integer limit
+    ) {
+
+        return CommonResponse.success(
+                materializedService.getStats(ownerId, period, limit)
+        );
     }
 }

--- a/src/main/java/com/bready/server/stats/service/PlanStatsJoinService.java
+++ b/src/main/java/com/bready/server/stats/service/PlanStatsJoinService.java
@@ -20,7 +20,7 @@ import java.util.stream.Collectors;
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
-public class PlanListStatsService {
+public class PlanStatsJoinService {
 
     private static final int DEFAULT_LIMIT = 20;
     private static final int MAX_LIMIT = 50;
@@ -28,7 +28,7 @@ public class PlanListStatsService {
     private final PlanRepository planRepository;
     private final PlanCategoryRepository categoryRepository;
 
-    public PlanStatsResponse getPlanStats(
+    public PlanStatsResponse getStats(
             Long ownerId,
             StatsPeriod period,
             Integer limitParam

--- a/src/main/java/com/bready/server/stats/service/PlanStatsMaterializedService.java
+++ b/src/main/java/com/bready/server/stats/service/PlanStatsMaterializedService.java
@@ -1,0 +1,28 @@
+package com.bready.server.stats.service;
+
+import com.bready.server.stats.domain.StatsPeriod;
+import com.bready.server.stats.dto.PlanStatsResponse;
+import com.bready.server.stats.repository.PlanStatsRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PlanStatsMaterializedService {
+
+    private final PlanStatsRepository planStatsRepository;
+
+    public PlanStatsResponse getStats(
+            Long ownerId,
+            StatsPeriod period,
+            Integer limit
+    ) {
+
+        // 아직 구현 안함 (JOIN 성능 먼저 측정해야 비교 가능.)
+        throw new UnsupportedOperationException(
+                "Materialized stats not implemented yet"
+        );
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #51 

## 📝 작업 내용

### JOIN 기반 통계 API 부하 테스트 수행
- 통계 API가 실제 트래픽 환경에서도 안정적으로 동작하는지 검증하기 위해 k6 기반 부하 테스트를 진행했습니다.


### 테스트 시나리오

```
최대 동시 사용자(VU): 80명

테스트 시간: 약 2분

대상 API: GET /api/v1/stats/plans/join

```

### 테스트 결과 (핵심)
**1. DB Connection Pool 고갈 발생**

동시 요청 증가 시 HikariPool의 모든 커넥션이 점유되며 추가 요청이 대기 상태에 진입했고, 결국 timeout이 발생했습니다.

```
48:17.525+09:00  INFO 4148 --- [o-8080-exec-174] c.b.server.global.aop.LoggingAspect      : [START] com.bready.server.stats.service.PlanStatsJoinService.getStats() args = [1, WEEK, 10]
2026-02-10T22:48:18.305+09:00  WARN 4148 --- [o-8080-exec-175] o.h.engine.jdbc.spi.SqlExceptionHelper   : SQL Error: 0, SQLState: null
2026-02-10T22:48:18.305+09:00 ERROR 4148 --- [o-8080-exec-175] o.h.engine.jdbc.spi.SqlExceptionHelper   : HikariPool-1 - Connection is not available, request timed out after 30002ms (total=10, active=10, idle=0, waiting=2)
2026-02-10T22:48:18.306+09:00 ERROR 4148 --- [o-8080-exec-175] c.b.s.g.e.GlobalExceptionHandler         : [UnexpectedException]

org.springframework.transaction.CannotCreateTransactionException: Could not open JPA EntityManager for transaction
```

**2. API 응답 시간 급증**

Execution Time: 57,756ms

→ 일부 요청은 약 57초 이상 소요되었습니다.
```

2026-02-10T22:48:17.242+09:00  WARN 4148 --- [o-8080-exec-112] .m.m.a.ExceptionHandlerExceptionResolver : Resolved [org.springframework.transaction.CannotCreateTransactionException: Could not open JPA EntityManager for transaction]
2026-02-10T22:48:17.507+09:00  INFO 4148 --- [io-8080-exec-10] c.b.server.global.aop.LoggingAspect      : [ END ] com.bready.server.stats.service.PlanStatsJoinService.getStats()
2026-02-10T22:48:17.520+09:00  INFO 4148 --- [io-8080-exec-10] c.b.s.global.aop.ExecutionTimeAspect     : [API 실행 시간] 57756ms - com.bready.server.stats.controller.PlanStatsController.getJoinStats
```

**3. k6 결과**

p95: 10s

실패율: 100%

=> 정상적인 서비스 제공이 불가능한 수준의 병목 확인.

```
join_load_test ↓ [ 100% ] 23/80 VUs  2m0s


  █ THRESHOLDS

    http_req_duration
    ✗ 'p(95)<600' p(95)=10s

    http_req_failed
    ✗ 'rate<0.01' rate=100.00%


  █ TOTAL RESULTS

    checks_total.......: 493     3.840687/s
    checks_succeeded...: 0.00%   0 out of 493
    checks_failed......: 100.00% 493 out of 493

    ✗ JOIN 200
      ↳  0% — ✓ 0 / ✗ 493

    HTTP
    http_req_duration....: avg=9.98s min=9.91s med=9.99s max=10.01s p(90)=9.99s  p(95)=10s
    http_req_failed......: 100.00% 493 out of 493
    http_reqs............: 493     3.840687/s

    EXECUTION
    iteration_duration...: avg=11s   min=11s   med=11s   max=11.04s p(90)=11.01s p(95)=11.01s
    iterations...........: 493     3.840687/s
    vus..................: 1       min=1          max=80
    vus_max..............: 80      min=80         max=80

    NETWORK
    data_received........: 0 B     0 B/s
    data_sent............: 145 kB  1.1 kB/s




running (2m08.4s), 00/80 VUs, 493 complete and 0 interrupted iterations
join_load_test ✓ [ 100% ] 00/80 VUs  2m0s
```


### 원인 분석
현재 통계 조회는 다수의 테이블을 JOIN하는 구조로 되어 있어 트래픽이 증가하면 쿼리 실행 시간이 길어지고 커넥션 점유 시간이 증가하며 결과적으로 Pool 고갈 발생하는 구조적인 성능 문제로 판단했습니다.


### 추후 개선 
JOIN 기반 실시간 집계 방식 대신 Materialized Stats 구조 도입 검토 



## 🖼️ 스크린샷 (선택)
### k6 결과 (p95 = 10s, failure 100%)
<img width="1185" height="815" alt="k6결과" src="https://github.com/user-attachments/assets/3d2435be-4980-47d6-a0e3-6ec65af201d6" />

### HikariPool timeout 로그 및 API 응답 시간
<img width="1830" height="505" alt="커넥션풀터진거결과" src="https://github.com/user-attachments/assets/07b6bca5-383f-4aa7-9c64-dd77ea8a88b2" />


## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특히 봐주었으면 하는 부분이 있다면 작성해주세요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경 사항

* **새로운 기능**
  * 플랜 통계 조회를 위한 두 가지 새로운 엔드포인트가 추가되었습니다.
  * 각 엔드포인트는 통계 기간과 조회 제한값을 매개변수로 받아 맞춤형 통계 데이터를 제공합니다.
  * 사용자의 소유권 정보와 함께 더욱 정교한 플랜 통계 조회가 가능해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->