### PR TITLE
[refactor] 플랜별 통계 조회 API 1차 성능개선 

### DIFF
--- a/src/main/java/com/bready/server/plan/repository/PlanCategoryRepository.java
+++ b/src/main/java/com/bready/server/plan/repository/PlanCategoryRepository.java
@@ -24,6 +24,17 @@ public interface PlanCategoryRepository extends JpaRepository<PlanCategory, Long
     """)
     List<PlanCategoryTypeRow> findCategoryTypesByOwner(@Param("ownerId") Long ownerId);
 
+
+    // planIds로만 category 조회 (성능 개선)
+    @Query("""
+        select
+            pc.plan.id as planId,
+            pc.categoryType as categoryType
+        from PlanCategory pc
+        where pc.plan.id in :planIds
+    """)
+    List<PlanCategoryTypeRow> findCategoryTypesByPlanIds(@Param("planIds") List<Long> planIds);
+
     // 장소 후보쪽에서 category가 plan에 속하는지 검증하기 위해서 추가
     Optional<PlanCategory> findByIdAndPlan_Id(Long id, Long planId);
 }

--- a/src/main/java/com/bready/server/plan/repository/PlanRepository.java
+++ b/src/main/java/com/bready/server/plan/repository/PlanRepository.java
@@ -74,6 +74,7 @@ public interface PlanRepository extends JpaRepository<Plan, Long> {
         SELECT id, title, plan_date, region
         FROM plans
         WHERE owner_id = :ownerId
+            AND deleted_at IS NULL
         ORDER BY plan_date DESC
         LIMIT :limit
     ) p

--- a/src/main/java/com/bready/server/plan/repository/PlanRepository.java
+++ b/src/main/java/com/bready/server/plan/repository/PlanRepository.java
@@ -78,9 +78,9 @@ public interface PlanRepository extends JpaRepository<Plan, Long> {
         ORDER BY plan_date DESC
         LIMIT :limit
     ) p
-    LEFT JOIN triggers t ON t.plan_id = p.id
-    LEFT JOIN decisions d ON d.trigger_id = t.id
-    LEFT JOIN switch_logs sl ON sl.decision_id = d.id
+    LEFT JOIN triggers t ON t.plan_id = p.id AND t.deleted_at IS NULL
+    LEFT JOIN decisions d ON d.trigger_id = t.id AND d.deleted_at IS NULL
+    LEFT JOIN switch_logs sl ON sl.decision_id = d.id AND sl.deleted_at IS NULL
     GROUP BY p.id, p.title, p.plan_date, p.region
     ORDER BY p.plan_date DESC
     """, nativeQuery = true)

--- a/src/main/java/com/bready/server/plan/repository/PlanRepository.java
+++ b/src/main/java/com/bready/server/plan/repository/PlanRepository.java
@@ -75,17 +75,17 @@ public interface PlanRepository extends JpaRepository<Plan, Long> {
         FROM plans
         WHERE owner_id = :ownerId
         ORDER BY plan_date DESC
+        LIMIT :limit
     ) p
     LEFT JOIN triggers t ON t.plan_id = p.id
     LEFT JOIN decisions d ON d.trigger_id = t.id
     LEFT JOIN switch_logs sl ON sl.decision_id = d.id
     GROUP BY p.id, p.title, p.plan_date, p.region
     ORDER BY p.plan_date DESC
-    """,
-            nativeQuery = true)
+    """, nativeQuery = true)
     List<PlanSwitchStatsRow> findPlanSwitchStatsOptimized(
             @Param("ownerId") Long ownerId,
-            Pageable pageable
+            @Param("limit") int limit
     );
 
 }

--- a/src/main/java/com/bready/server/plan/repository/PlanRepository.java
+++ b/src/main/java/com/bready/server/plan/repository/PlanRepository.java
@@ -23,6 +23,7 @@ public interface PlanRepository extends JpaRepository<Plan, Long> {
         Long getTotalSwitches();
     }
 
+    /*
     @Query("""
         select
             p.id as planId,
@@ -42,6 +43,7 @@ public interface PlanRepository extends JpaRepository<Plan, Long> {
             @Param("ownerId") Long ownerId,
             Pageable pageable
     );
+     */
 
     @Query("""
         select p
@@ -59,5 +61,31 @@ public interface PlanRepository extends JpaRepository<Plan, Long> {
     long countByOwnerId(@Param("ownerId") Long ownerId);
 
     Optional<Plan> findByIdAndDeletedAtIsNull(Long id);
+
+
+    @Query(value = """
+    SELECT
+        p.id as planId,
+        p.title as planTitle,
+        p.plan_date as planDate,
+        p.region as region,
+        COALESCE(COUNT(sl.id),0) as totalSwitches
+    FROM (
+        SELECT id, title, plan_date, region
+        FROM plans
+        WHERE owner_id = :ownerId
+        ORDER BY plan_date DESC
+    ) p
+    LEFT JOIN triggers t ON t.plan_id = p.id
+    LEFT JOIN decisions d ON d.trigger_id = t.id
+    LEFT JOIN switch_logs sl ON sl.decision_id = d.id
+    GROUP BY p.id, p.title, p.plan_date, p.region
+    ORDER BY p.plan_date DESC
+    """,
+            nativeQuery = true)
+    List<PlanSwitchStatsRow> findPlanSwitchStatsOptimized(
+            @Param("ownerId") Long ownerId,
+            Pageable pageable
+    );
 
 }

--- a/src/main/java/com/bready/server/stats/service/PlanStatsJoinService.java
+++ b/src/main/java/com/bready/server/stats/service/PlanStatsJoinService.java
@@ -38,7 +38,7 @@ public class PlanStatsJoinService {
 
         // JOIN 기반 통계 rows (limit만큼만)
         List<PlanRepository.PlanSwitchStatsRow> rows =
-                planRepository.findPlanSwitchStats(ownerId, pageable);
+                planRepository.findPlanSwitchStatsOptimized(ownerId, pageable);
 
         if (rows.isEmpty()) {
             return PlanStatsResponse.builder()

--- a/src/main/java/com/bready/server/stats/service/PlanStatsJoinService.java
+++ b/src/main/java/com/bready/server/stats/service/PlanStatsJoinService.java
@@ -33,15 +33,28 @@ public class PlanStatsJoinService {
             StatsPeriod period,
             Integer limitParam
     ) {
-
         int limit = normalizeLimit(limitParam);
-
         Pageable pageable = PageRequest.of(0, limit);
 
-        List<PlanRepository.PlanSwitchStatsRow> rows = planRepository.findPlanSwitchStats(ownerId, pageable);
+        // JOIN 기반 통계 rows (limit만큼만)
+        List<PlanRepository.PlanSwitchStatsRow> rows =
+                planRepository.findPlanSwitchStats(ownerId, pageable);
+
+        if (rows.isEmpty()) {
+            return PlanStatsResponse.builder()
+                    .period(period)
+                    .items(List.of())
+                    .build();
+        }
+
+        // rows에 포함된 planIds만 뽑아서 IN 조회
+        List<Long> planIds = rows.stream()
+                .map(PlanRepository.PlanSwitchStatsRow::getPlanId)
+                .distinct()
+                .toList();
 
         Map<Long, List<String>> categoryMap =
-                categoryRepository.findCategoryTypesByOwner(ownerId)
+                categoryRepository.findCategoryTypesByPlanIds(planIds)
                         .stream()
                         .collect(Collectors.groupingBy(
                                 PlanCategoryRepository.PlanCategoryTypeRow::getPlanId,
@@ -57,12 +70,7 @@ public class PlanStatsJoinService {
                         .planTitle(row.getPlanTitle())
                         .planDate(row.getPlanDate())
                         .region(row.getRegion())
-                        .categoryTypes(
-                                categoryMap.getOrDefault(
-                                        row.getPlanId(),
-                                        List.of()
-                                )
-                        )
+                        .categoryTypes(categoryMap.getOrDefault(row.getPlanId(), List.of()))
                         .totalSwitches(row.getTotalSwitches())
                         .build())
                 .toList();

--- a/src/main/java/com/bready/server/stats/service/PlanStatsJoinService.java
+++ b/src/main/java/com/bready/server/stats/service/PlanStatsJoinService.java
@@ -8,8 +8,6 @@ import com.bready.server.stats.dto.PlanStatsItem;
 import com.bready.server.stats.dto.PlanStatsResponse;
 import com.bready.server.stats.exception.StatsErrorCase;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -34,11 +32,10 @@ public class PlanStatsJoinService {
             Integer limitParam
     ) {
         int limit = normalizeLimit(limitParam);
-        Pageable pageable = PageRequest.of(0, limit);
 
         // JOIN 기반 통계 rows (limit만큼만)
         List<PlanRepository.PlanSwitchStatsRow> rows =
-                planRepository.findPlanSwitchStatsOptimized(ownerId, pageable);
+                planRepository.findPlanSwitchStatsOptimized(ownerId, limit);
 
         if (rows.isEmpty()) {
             return PlanStatsResponse.builder()


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #54 

## 📝 작업 내용
플랜별 통계 조회 API(/api/v1/stats/plans/join) 호출 시 약 5~6초 이상의 응답 지연이 발생하는 문제가 확인되었습니다.
실시간 통계 API 특성상 사용자 경험에 치명적인 영향을 줄 수 있으며, 트래픽 증가 시 DB 커넥션 풀 고갈 및 서버 장애로 이어질 가능성이 있어 성능 분석 및 개선을 진행했습니다.

### 문제 원인 도출
**1. API 실행 로그**
- API 실행 시간: 5506ms
- 단순 네트워크 문제가 아닌 DB 쿼리 레벨 병목으로 판단

Hibernate SQL 로그 분석 결과:
```
select
    p.id,
    p.title,
    p.plan_date,
    p.region,
    count(sl.id)
from plans p
left join triggers t on t.plan_id=p.id
left join decisions d on d.trigger_id=t.id
left join switch_logs sl on sl.decision_id=d.id
where p.owner_id=?
group by ...
order by p.plan_date desc
limit ?
```

JOIN 대상 테이블:
```
plans
triggers
decisions
switch_logs

```
=> 통계성 쿼리에서 다중 LEFT JOIN + GROUP BY 구조가 확인되었습니다.

**2. 원인 분석**
- MySQL EXPLAIN ANALYZE 결과
```
Nested loop left join
(actual rows=501000)

Aggregate using temporary table
(actual time=4990ms)

Table scan on <temporary>
```
=> 핵심 병목: MySQL이 약 50만 row를 생성 후 GROUP BY 수행

해당 로직의 가장 큰 문제는 
```
plans 전체 조회 (약 2000건)
   ↓
JOIN 수행
   ↓
50만 row 생성
   ↓
GROUP BY
   ↓
정렬
   ↓
LIMIT 10

```
=> LIMIT이 가장 마지막에 적용됨.

때문에 트래픽 증가 시 DB CPU 급상승, 커넥션 풀 고갈등으로 실제 서비스 장애로 이어짐 (이전 PR에서 부하테스트로 확인)

**3. 추가 성능 리스크 발견**
카테고리 조회 쿼리
```
select
    p.id,
    pc.category_type
from plan_categories pc
join plans p on p.id = pc.plan_id
where p.owner_id=?
```
=> 문제: 통계 대상은 10개 플랜인데 owner 전체 카테고리를 조회하고 있음


###  성능 개선 
**개선 1 — LIMIT Push Down (Native Query 도입)**
개선 구조
```
FROM (
    SELECT id, title, plan_date, region
    FROM plans
    WHERE owner_id = ?
    ORDER BY plan_date DESC
    LIMIT ?
) p
LEFT JOIN triggers .
```
변경된 실행 흐름
```
Before
2000 plans
 → JOIN
 → 50만 rows
 → GROUP BY
 → LIMIT
After
LIMIT 10
 → JOIN
 → GROUP BY
```
=> 처리 row 자체가 감소하여 DB 연산량 대폭 감소.

**개선 2 — 카테고리 조회 범위 축소**
- owner 전체 카테고리 조회에서 통계 대상 플랜만 조회하도록 변경.


### 성능 개선 결과
```
Before
API 실행 시간: 5506ms
After
API 실행 시간: 138ms
```
=> 약 40배 성능 개선 확인 완료 


## 🖼️ 스크린샷 (선택)
### 성능 개선 전 API 응답 시간 (5506ms)
```
2026-02-11T23:48:34.177+09:00  INFO 5284 --- [nio-8080-exec-5] c.b.server.global.aop.LoggingAspect      : [START] com.bready.server.stats.service.PlanStatsJoinService.getStats() args = [1, WEEK, 10]
2026-02-11T23:48:34.198+09:00 DEBUG 5284 --- [nio-8080-exec-5] org.hibernate.SQL                        : 
    select
        p1_0.id,
        p1_0.title,
        p1_0.plan_date,
        p1_0.region,
        count(sl1_0.id) 
    from
        plans p1_0 
    left join
        triggers t1_0 
            on t1_0.plan_id=p1_0.id 
    left join
        decisions d1_0 
            on d1_0.trigger_id=t1_0.id 
    left join
        switch_logs sl1_0 
            on sl1_0.decision_id=d1_0.id 
    where
        p1_0.owner_id=? 
    group by
        p1_0.id,
        p1_0.title,
        p1_0.plan_date,
        p1_0.region 
    order by
        p1_0.plan_date desc 
    limit
        ?
2026-02-11T23:48:34.199+09:00 TRACE 5284 --- [nio-8080-exec-5] org.hibernate.orm.jdbc.bind              : binding parameter (1:BIGINT) <- [1]
2026-02-11T23:48:34.199+09:00 TRACE 5284 --- [nio-8080-exec-5] org.hibernate.orm.jdbc.bind              : binding parameter (2:INTEGER) <- [10]
2026-02-11T23:48:39.651+09:00 DEBUG 5284 --- [nio-8080-exec-5] org.hibernate.SQL                        : 
    select
        p1_0.id,
        pc1_0.category_type 
    from
        plan_categories pc1_0 
    join
        plans p1_0 
            on p1_0.id=pc1_0.plan_id 
    where
        p1_0.owner_id=?
2026-02-11T23:48:39.651+09:00 TRACE 5284 --- [nio-8080-exec-5] org.hibernate.orm.jdbc.bind              : binding parameter (1:BIGINT) <- [1]
2026-02-11T23:48:39.659+09:00  INFO 5284 --- [nio-8080-exec-5] c.b.server.global.aop.LoggingAspect      : [ END ] com.bready.server.stats.service.PlanStatsJoinService.getStats()
2026-02-11T23:48:39.664+09:00  INFO 5284 --- [nio-8080-exec-5] c.b.s.global.aop.ExecutionTimeAspect     : [API 실행 시간] 5506ms - com.bready.server.stats.controller.PlanStatsController.getJoinStats
```

### 성능 개선 (DB 쿼리 변경) 후 API 응답 시간 (138ms)
```
2026-02-12T00:23:34.932+09:00  INFO 7412 --- [nio-8080-exec-2] c.b.server.global.aop.LoggingAspect      : [START] com.bready.server.stats.service.PlanStatsJoinService.getStats() args = [1, WEEK, 10]
2026-02-12T00:23:34.957+09:00 DEBUG 7412 --- [nio-8080-exec-2] org.hibernate.SQL                        : 
    SELECT
        p.id as planId,
        p.title as planTitle,
        p.plan_date as planDate,
        p.region as region,
        COALESCE(COUNT(sl.id), 0) as totalSwitches 
    FROM
        (     SELECT
            id,
            title,
            plan_date,
            region     
        FROM
            plans     
        WHERE
            owner_id = ?     
        ORDER BY
            plan_date DESC     
        LIMIT
            ? ) p 
    LEFT JOIN
        triggers t 
            ON t.plan_id = p.id 
    LEFT JOIN
        decisions d 
            ON d.trigger_id = t.id 
    LEFT JOIN
        switch_logs sl 
            ON sl.decision_id = d.id 
    GROUP BY
        p.id,
        p.title,
        p.plan_date,
        p.region 
    ORDER BY
        p.plan_date DESC 
2026-02-12T00:23:34.958+09:00 TRACE 7412 --- [nio-8080-exec-2] org.hibernate.orm.jdbc.bind              : binding parameter (1:BIGINT) <- [1]
2026-02-12T00:23:34.958+09:00 TRACE 7412 --- [nio-8080-exec-2] org.hibernate.orm.jdbc.bind              : binding parameter (2:INTEGER) <- [10]
2026-02-12T00:23:35.037+09:00 DEBUG 7412 --- [nio-8080-exec-2] org.hibernate.SQL                        : 
    select
        pc1_0.plan_id,
        pc1_0.category_type 
    from
        plan_categories pc1_0 
    where
        pc1_0.plan_id in (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
2026-02-12T00:23:35.037+09:00 TRACE 7412 --- [nio-8080-exec-2] org.hibernate.orm.jdbc.bind              : binding parameter (1:BIGINT) <- [42]
2026-02-12T00:23:35.037+09:00 TRACE 7412 --- [nio-8080-exec-2] org.hibernate.orm.jdbc.bind              : binding parameter (2:BIGINT) <- [182]
2026-02-12T00:23:35.037+09:00 TRACE 7412 --- [nio-8080-exec-2] org.hibernate.orm.jdbc.bind              : binding parameter (3:BIGINT) <- [122]
2026-02-12T00:23:35.037+09:00 TRACE 7412 --- [nio-8080-exec-2] org.hibernate.orm.jdbc.bind              : binding parameter (4:BIGINT) <- [292]
2026-02-12T00:23:35.038+09:00 TRACE 7412 --- [nio-8080-exec-2] org.hibernate.orm.jdbc.bind              : binding parameter (5:BIGINT) <- [72]
2026-02-12T00:23:35.038+09:00 TRACE 7412 --- [nio-8080-exec-2] org.hibernate.orm.jdbc.bind              : binding parameter (6:BIGINT) <- [152]
2026-02-12T00:23:35.038+09:00 TRACE 7412 --- [nio-8080-exec-2] org.hibernate.orm.jdbc.bind              : binding parameter (7:BIGINT) <- [232]
2026-02-12T00:23:35.038+09:00 TRACE 7412 --- [nio-8080-exec-2] org.hibernate.orm.jdbc.bind              : binding parameter (8:BIGINT) <- [202]
2026-02-12T00:23:35.038+09:00 TRACE 7412 --- [nio-8080-exec-2] org.hibernate.orm.jdbc.bind              : binding parameter (9:BIGINT) <- [262]
2026-02-12T00:23:35.038+09:00 TRACE 7412 --- [nio-8080-exec-2] org.hibernate.orm.jdbc.bind              : binding parameter (10:BIGINT) <- [12]
2026-02-12T00:23:35.046+09:00  INFO 7412 --- [nio-8080-exec-2] c.b.server.global.aop.LoggingAspect      : [ END ] com.bready.server.stats.service.PlanStatsJoinService.getStats()
2026-02-12T00:23:35.052+09:00  INFO 7412 --- [nio-8080-exec-2] c.b.s.global.aop.ExecutionTimeAspect     : [API 실행 시간] 138ms - com.bready.server.stats.controller.PlanStatsController.getJoinStats
```

## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특히 봐주었으면 하는 부분이 있다면 작성해주세요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **성능 최적화**
  * 주요 조회 로직을 최적화해 응답 시간이 단축되었습니다.
  * 제한된 결과 집합으로 가져오는 방식으로 필터링 효율을 높였습니다.
  * 불필요한 페이징 로직을 제거하고 조회 경로를 단순화했습니다.
  * 빈 결과에 대한 빠른 단축 처리를 추가해 불필요한 후속 작업을 방지합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->