### PR TITLE
[feat]  플랜 카테고리 관리 API 구현

### DIFF
--- a/src/main/java/com/bready/server/place/service/PlaceCandidateService.java
+++ b/src/main/java/com/bready/server/place/service/PlaceCandidateService.java
@@ -34,7 +34,7 @@ public class PlaceCandidateService {
 
         // planId + categoryId 매칭 검증
         PlanCategory category = planCategoryRepository
-                .findByIdAndPlan_Id(request.categoryId(), request.planId())
+                .findByIdAndPlan_IdAndDeletedAtIsNull(request.categoryId(), request.planId())
                 .orElseThrow(() -> ApplicationException.from(PlaceErrorCase.INVALID_PLAN_OR_CATEGORY));
 
         // Place는 중복이면 재사용 (REQUIRES_NEW로 분리된 빈 호출)

--- a/src/main/java/com/bready/server/plan/controller/PlanCategoryController.java
+++ b/src/main/java/com/bready/server/plan/controller/PlanCategoryController.java
@@ -2,9 +2,7 @@ package com.bready.server.plan.controller;
 
 import com.bready.server.global.auth.CurrentUser;
 import com.bready.server.global.response.CommonResponse;
-import com.bready.server.plan.dto.PlanCategoryCreateRequest;
-import com.bready.server.plan.dto.PlanCategoryCreateResponse;
-import com.bready.server.plan.dto.PlanCategoryDeleteResponse;
+import com.bready.server.plan.dto.*;
 import com.bready.server.plan.service.PlanCategoryService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -76,5 +74,34 @@ public class PlanCategoryController {
             @PathVariable Long planCategoryId
     ) {
         return CommonResponse.success(planCategoryService.deleteCategory(userId, planId, planCategoryId));
+    }
+
+
+    @PatchMapping("/order")
+    @ResponseStatus(HttpStatus.OK)
+    @Operation(
+            summary = "카테고리 순서 변경",
+            description = "플랜에 속한 카테고리들의 순서를 일괄 변경합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "카테고리 순서 변경 성공",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "400", description = "요청 값 오류",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "401", description = "인증 필요",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "403", description = "카테고리 수정 권한 없음",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "404", description = "플랜 또는 카테고리 없음",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "500", description = "서버 오류",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class)))
+    })
+    public CommonResponse<PlanCategoryOrderUpdateResponse> updateCategoryOrder(
+            @CurrentUser Long userId,
+            @PathVariable Long planId,
+            @Valid @RequestBody PlanCategoryOrderUpdateRequest request
+    ) {
+        return CommonResponse.success(planCategoryService.updateCategoryOrder(userId, planId, request));
     }
 }

--- a/src/main/java/com/bready/server/plan/controller/PlanCategoryController.java
+++ b/src/main/java/com/bready/server/plan/controller/PlanCategoryController.java
@@ -1,0 +1,52 @@
+package com.bready.server.plan.controller;
+
+import com.bready.server.global.auth.CurrentUser;
+import com.bready.server.global.response.CommonResponse;
+import com.bready.server.plan.dto.PlanCategoryCreateRequest;
+import com.bready.server.plan.dto.PlanCategoryCreateResponse;
+import com.bready.server.plan.service.PlanCategoryService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/plans/{planId}/categories")
+public class PlanCategoryController {
+
+    private final PlanCategoryService planCategoryService;
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    @Operation(
+            summary = "카테고리 추가",
+            description = "플랜에 카테고리를 추가합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "카테고리 추가 성공",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "400", description = "요청 값 오류 (누락/형식오류)",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "401", description = "인증 필요",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "403", description = "카테고리 추가 권한 없음",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "404", description = "플랜 없음",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "500", description = "카테고리 추가 실패 (서버 오류)",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class)))
+    })
+    public CommonResponse<PlanCategoryCreateResponse> addCategory(
+            @CurrentUser Long userId,
+            @PathVariable Long planId,
+            @Valid @RequestBody PlanCategoryCreateRequest request
+    ) {
+        return CommonResponse.success(planCategoryService.addCategory(userId, planId, request));
+    }
+}

--- a/src/main/java/com/bready/server/plan/controller/PlanCategoryController.java
+++ b/src/main/java/com/bready/server/plan/controller/PlanCategoryController.java
@@ -4,6 +4,7 @@ import com.bready.server.global.auth.CurrentUser;
 import com.bready.server.global.response.CommonResponse;
 import com.bready.server.plan.dto.PlanCategoryCreateRequest;
 import com.bready.server.plan.dto.PlanCategoryCreateResponse;
+import com.bready.server.plan.dto.PlanCategoryDeleteResponse;
 import com.bready.server.plan.service.PlanCategoryService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -48,5 +49,32 @@ public class PlanCategoryController {
             @Valid @RequestBody PlanCategoryCreateRequest request
     ) {
         return CommonResponse.success(planCategoryService.addCategory(userId, planId, request));
+    }
+
+
+    @DeleteMapping("/{planCategoryId}")
+    @ResponseStatus(HttpStatus.OK)
+    @Operation(
+            summary = "카테고리 삭제",
+            description = "인증된 사용자가 플랜에 속한 카테고리 삭제 (soft delete)"
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "카테고리 삭제 성공",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "401", description = "인증 필요",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "403", description = "카테고리 삭제 권한 없음",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "404", description = "플랜 또는 카테고리 없음",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "500", description = "카테고리 삭제 실패 (서버 오류)",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class)))
+    })
+    public CommonResponse<PlanCategoryDeleteResponse> deleteCategory(
+            @CurrentUser Long userId,
+            @PathVariable Long planId,
+            @PathVariable Long planCategoryId
+    ) {
+        return CommonResponse.success(planCategoryService.deleteCategory(userId, planId, planCategoryId));
     }
 }

--- a/src/main/java/com/bready/server/plan/domain/PlanCategory.java
+++ b/src/main/java/com/bready/server/plan/domain/PlanCategory.java
@@ -27,4 +27,12 @@ public class PlanCategory extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "plan_id", nullable = false)
     private Plan plan; // plan과의 연관관계 설정 (1:N)
+
+    public static PlanCategory create(Plan plan, PlaceCategoryType categoryType, Integer sequence) {
+        PlanCategory category = new PlanCategory();
+        category.plan = plan;
+        category.categoryType = categoryType;
+        category.sequence = sequence;
+        return category;
+    }
 }

--- a/src/main/java/com/bready/server/plan/domain/PlanCategory.java
+++ b/src/main/java/com/bready/server/plan/domain/PlanCategory.java
@@ -35,4 +35,8 @@ public class PlanCategory extends BaseEntity {
         category.sequence = sequence;
         return category;
     }
+
+    public void updateSequence(Integer sequence) {
+        this.sequence = sequence;
+    }
 }

--- a/src/main/java/com/bready/server/plan/dto/PlanCategoryCreateRequest.java
+++ b/src/main/java/com/bready/server/plan/dto/PlanCategoryCreateRequest.java
@@ -10,7 +10,4 @@ public class PlanCategoryCreateRequest {
     @NotNull(message = "categoryType은 필수입니다.")
     private PlaceCategoryType categoryType;
 
-    @NotNull(message = "sequence는 필수입니다.")
-    private Integer sequence;
-
 }

--- a/src/main/java/com/bready/server/plan/dto/PlanCategoryCreateRequest.java
+++ b/src/main/java/com/bready/server/plan/dto/PlanCategoryCreateRequest.java
@@ -1,0 +1,16 @@
+package com.bready.server.plan.dto;
+
+import com.bready.server.place.domain.PlaceCategoryType;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
+public class PlanCategoryCreateRequest {
+
+    @NotNull(message = "categoryType은 필수입니다.")
+    private PlaceCategoryType categoryType;
+
+    @NotNull(message = "sequence는 필수입니다.")
+    private Integer sequence;
+
+}

--- a/src/main/java/com/bready/server/plan/dto/PlanCategoryCreateResponse.java
+++ b/src/main/java/com/bready/server/plan/dto/PlanCategoryCreateResponse.java
@@ -1,0 +1,19 @@
+package com.bready.server.plan.dto;
+
+import com.bready.server.place.domain.PlaceCategoryType;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class PlanCategoryCreateResponse {
+
+    private Long planCategoryId;
+    private Long planId;
+    private PlaceCategoryType categoryType;
+    private Integer sequence;
+    private LocalDateTime createdAt;
+
+}

--- a/src/main/java/com/bready/server/plan/dto/PlanCategoryDeleteResponse.java
+++ b/src/main/java/com/bready/server/plan/dto/PlanCategoryDeleteResponse.java
@@ -1,0 +1,16 @@
+package com.bready.server.plan.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class PlanCategoryDeleteResponse {
+
+    private Long planId;
+    private Long planCategoryId;
+    private LocalDateTime deletedAt;
+
+}

--- a/src/main/java/com/bready/server/plan/dto/PlanCategoryItemDto.java
+++ b/src/main/java/com/bready/server/plan/dto/PlanCategoryItemDto.java
@@ -1,0 +1,15 @@
+package com.bready.server.plan.dto;
+
+import com.bready.server.place.domain.PlaceCategoryType;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class PlanCategoryItemDto {
+
+    private Long planCategoryId;
+    private PlaceCategoryType categoryType;
+    private Integer sequence;
+
+}

--- a/src/main/java/com/bready/server/plan/dto/PlanCategoryOrderUpdateRequest.java
+++ b/src/main/java/com/bready/server/plan/dto/PlanCategoryOrderUpdateRequest.java
@@ -1,6 +1,7 @@
 package com.bready.server.plan.dto;
 
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
@@ -21,6 +22,7 @@ public class PlanCategoryOrderUpdateRequest {
         private Long planCategoryId;
 
         @NotNull(message = "sequence는 필수입니다.")
+        @Min(value = 1, message = "sequence는 1 이상이어야 합니다.")
         private Integer sequence;
 
     }

--- a/src/main/java/com/bready/server/plan/dto/PlanCategoryOrderUpdateRequest.java
+++ b/src/main/java/com/bready/server/plan/dto/PlanCategoryOrderUpdateRequest.java
@@ -1,0 +1,27 @@
+package com.bready.server.plan.dto;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class PlanCategoryOrderUpdateRequest {
+
+    @NotEmpty(message = "orders는 비어있을 수 없습니다.")
+    @Valid
+    private List<OrderItem> orders;
+
+    @Getter
+    public static class OrderItem {
+
+        @NotNull(message = "planCategoryId는 필수입니다.")
+        private Long planCategoryId;
+
+        @NotNull(message = "sequence는 필수입니다.")
+        private Integer sequence;
+
+    }
+}

--- a/src/main/java/com/bready/server/plan/dto/PlanCategoryOrderUpdateResponse.java
+++ b/src/main/java/com/bready/server/plan/dto/PlanCategoryOrderUpdateResponse.java
@@ -1,0 +1,15 @@
+package com.bready.server.plan.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class PlanCategoryOrderUpdateResponse {
+
+    private Long planId;
+    private LocalDateTime updatedAt;
+
+}

--- a/src/main/java/com/bready/server/plan/dto/PlanDetailResponse.java
+++ b/src/main/java/com/bready/server/plan/dto/PlanDetailResponse.java
@@ -5,12 +5,14 @@ import lombok.Getter;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Getter
 @Builder
 public class PlanDetailResponse {
 
     private PlanDto plan;
+    private List<PlanCategoryItemDto> categories;
     // TODO : 장소, 카테고리 등 연결
 
 }

--- a/src/main/java/com/bready/server/plan/dto/PlanDetailResponse.java
+++ b/src/main/java/com/bready/server/plan/dto/PlanDetailResponse.java
@@ -12,7 +12,9 @@ import java.util.List;
 public class PlanDetailResponse {
 
     private PlanDto plan;
-    private List<PlanCategoryItemDto> categories;
-    // TODO : 장소, 카테고리 등 연결
 
+    @Builder.Default
+    private List<PlanCategoryItemDto> categories = List.of();
+
+    // TODO : 장소, 카테고리 등 연결
 }

--- a/src/main/java/com/bready/server/plan/exception/CategoryErrorCase.java
+++ b/src/main/java/com/bready/server/plan/exception/CategoryErrorCase.java
@@ -9,10 +9,10 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum CategoryErrorCase implements ErrorCase {
 
-    CATEGORY_ACCESS_DENIED(HttpStatus.FORBIDDEN, 4101, "카테고리에 대한 접근 권한이 없습니다."),
-    CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, 4102, "존재하지 않는 카테고리입니다."),
-    INVALID_SEQUENCE(HttpStatus.BAD_REQUEST, 4103, "sequence 값이 올바르지 않습니다."),
-    INVALID_ORDERS(HttpStatus.BAD_REQUEST, 4104, "orders 값이 올바르지 않습니다.");
+    CATEGORY_ACCESS_DENIED(HttpStatus.FORBIDDEN, 4201, "카테고리에 대한 접근 권한이 없습니다."),
+    CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, 4202, "존재하지 않는 카테고리입니다."),
+    INVALID_SEQUENCE(HttpStatus.BAD_REQUEST, 4203, "sequence 값이 올바르지 않습니다."),
+    INVALID_ORDERS(HttpStatus.BAD_REQUEST, 4204, "orders 값이 올바르지 않습니다.");
 
     private final HttpStatus httpStatus;
     private final Integer errorCode;

--- a/src/main/java/com/bready/server/plan/exception/CategoryErrorCase.java
+++ b/src/main/java/com/bready/server/plan/exception/CategoryErrorCase.java
@@ -11,7 +11,8 @@ public enum CategoryErrorCase implements ErrorCase {
 
     CATEGORY_ACCESS_DENIED(HttpStatus.FORBIDDEN, 4101, "카테고리에 대한 접근 권한이 없습니다."),
     CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, 4102, "존재하지 않는 카테고리입니다."),
-    INVALID_SEQUENCE(HttpStatus.BAD_REQUEST, 4103, "sequence 값이 올바르지 않습니다.");
+    INVALID_SEQUENCE(HttpStatus.BAD_REQUEST, 4103, "sequence 값이 올바르지 않습니다."),
+    INVALID_ORDERS(HttpStatus.BAD_REQUEST, 4104, "orders 값이 올바르지 않습니다.");
 
     private final HttpStatus httpStatus;
     private final Integer errorCode;

--- a/src/main/java/com/bready/server/plan/exception/CategoryErrorCase.java
+++ b/src/main/java/com/bready/server/plan/exception/CategoryErrorCase.java
@@ -1,0 +1,34 @@
+package com.bready.server.plan.exception;
+
+import com.bready.server.global.exception.ErrorCase;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum CategoryErrorCase implements ErrorCase {
+
+    CATEGORY_ACCESS_DENIED(HttpStatus.FORBIDDEN, 4101, "카테고리에 대한 접근 권한이 없습니다."),
+    CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, 4102, "존재하지 않는 카테고리입니다."),
+    INVALID_SEQUENCE(HttpStatus.BAD_REQUEST, 4103, "sequence 값이 올바르지 않습니다.");
+
+    private final HttpStatus httpStatus;
+    private final Integer errorCode;
+    private final String message;
+
+    @Override
+    public Integer getHttpStatusCode() {
+        return httpStatus.value();
+    }
+
+    @Override
+    public Integer getErrorCode() {
+        return errorCode;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/com/bready/server/plan/exception/PlanErrorCase.java
+++ b/src/main/java/com/bready/server/plan/exception/PlanErrorCase.java
@@ -21,14 +21,5 @@ public enum PlanErrorCase implements ErrorCase {
         return httpStatus.value();
     }
 
-    @Override
-    public Integer getErrorCode() {
-        return errorCode;
-    }
-
-    @Override
-    public String getMessage() {
-        return message;
-    }
 }
 

--- a/src/main/java/com/bready/server/plan/repository/PlanCategoryRepository.java
+++ b/src/main/java/com/bready/server/plan/repository/PlanCategoryRepository.java
@@ -24,9 +24,6 @@ public interface PlanCategoryRepository extends JpaRepository<PlanCategory, Long
     """)
     List<PlanCategoryTypeRow> findCategoryTypesByOwner(@Param("ownerId") Long ownerId);
 
-    // 장소 후보쪽에서 category가 plan에 속하는지 검증하기 위해서 추가
-    Optional<PlanCategory> findByIdAndPlan_Id(Long id, Long planId);
-
     Optional<PlanCategory> findByIdAndPlan_IdAndDeletedAtIsNull(Long id, Long planId);
 
     // 플랜 상세 조회에서 categories 조회용 (soft delete 차단 + sequence 정렬)

--- a/src/main/java/com/bready/server/plan/repository/PlanCategoryRepository.java
+++ b/src/main/java/com/bready/server/plan/repository/PlanCategoryRepository.java
@@ -1,10 +1,8 @@
 package com.bready.server.plan.repository;
 
 import com.bready.server.plan.domain.PlanCategory;
-import jakarta.persistence.LockModeType;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -32,8 +30,6 @@ public interface PlanCategoryRepository extends JpaRepository<PlanCategory, Long
     // 플랜 상세 조회에서 categories 조회용 (soft delete 차단 + sequence 정렬)
     List<PlanCategory> findAllByPlan_IdAndDeletedAtIsNullOrderBySequenceAsc(Long planId);
 
-    // addCategory 동시성 제어 - 동일 planId에 대해 마지막 sequence 행 잠금
-    @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("""
     select pc
     from PlanCategory pc
@@ -41,7 +37,7 @@ public interface PlanCategoryRepository extends JpaRepository<PlanCategory, Long
       and pc.deletedAt is null
     order by pc.sequence desc
 """)
-    List<PlanCategory> findLastByPlanIdForUpdate(@Param("planId") Long planId, Pageable pageable);
+    List<PlanCategory> findLastByPlanId(@Param("planId") Long planId, Pageable pageable);
 
 
     // planIds로만 category 조회 (성능 개선)

--- a/src/main/java/com/bready/server/plan/repository/PlanCategoryRepository.java
+++ b/src/main/java/com/bready/server/plan/repository/PlanCategoryRepository.java
@@ -26,4 +26,6 @@ public interface PlanCategoryRepository extends JpaRepository<PlanCategory, Long
 
     // 장소 후보쪽에서 category가 plan에 속하는지 검증하기 위해서 추가
     Optional<PlanCategory> findByIdAndPlan_Id(Long id, Long planId);
+
+    Optional<PlanCategory> findByIdAndPlan_IdAndDeletedAtIsNull(Long id, Long planId);
 }

--- a/src/main/java/com/bready/server/plan/repository/PlanCategoryRepository.java
+++ b/src/main/java/com/bready/server/plan/repository/PlanCategoryRepository.java
@@ -28,4 +28,7 @@ public interface PlanCategoryRepository extends JpaRepository<PlanCategory, Long
     Optional<PlanCategory> findByIdAndPlan_Id(Long id, Long planId);
 
     Optional<PlanCategory> findByIdAndPlan_IdAndDeletedAtIsNull(Long id, Long planId);
+
+    // 플랜 상세 조회에서 categories 조회용 (soft delete 차단 + sequence 정렬)
+    List<PlanCategory> findAllByPlan_IdAndDeletedAtIsNullOrderBySequenceAsc(Long planId);
 }

--- a/src/main/java/com/bready/server/plan/repository/PlanCategoryRepository.java
+++ b/src/main/java/com/bready/server/plan/repository/PlanCategoryRepository.java
@@ -1,7 +1,10 @@
 package com.bready.server.plan.repository;
 
 import com.bready.server.plan.domain.PlanCategory;
+import jakarta.persistence.LockModeType;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -29,13 +32,16 @@ public interface PlanCategoryRepository extends JpaRepository<PlanCategory, Long
     // 플랜 상세 조회에서 categories 조회용 (soft delete 차단 + sequence 정렬)
     List<PlanCategory> findAllByPlan_IdAndDeletedAtIsNullOrderBySequenceAsc(Long planId);
 
-    // sequence 자동 부여용 max sequence 조회
+    // addCategory 동시성 제어 - 동일 planId에 대해 마지막 sequence 행 잠금
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("""
-    select coalesce(max(pc.sequence), 0)
+    select pc
     from PlanCategory pc
     where pc.plan.id = :planId
       and pc.deletedAt is null
+    order by pc.sequence desc
 """)
-    Integer findMaxSequenceByPlanId(@Param("planId") Long planId);
+    List<PlanCategory> findLastByPlanIdForUpdate(@Param("planId") Long planId, Pageable pageable);
+
 
 }

--- a/src/main/java/com/bready/server/plan/repository/PlanCategoryRepository.java
+++ b/src/main/java/com/bready/server/plan/repository/PlanCategoryRepository.java
@@ -31,4 +31,14 @@ public interface PlanCategoryRepository extends JpaRepository<PlanCategory, Long
 
     // 플랜 상세 조회에서 categories 조회용 (soft delete 차단 + sequence 정렬)
     List<PlanCategory> findAllByPlan_IdAndDeletedAtIsNullOrderBySequenceAsc(Long planId);
+
+    // sequence 자동 부여용 max sequence 조회
+    @Query("""
+    select coalesce(max(pc.sequence), 0)
+    from PlanCategory pc
+    where pc.plan.id = :planId
+      and pc.deletedAt is null
+""")
+    Integer findMaxSequenceByPlanId(@Param("planId") Long planId);
+
 }

--- a/src/main/java/com/bready/server/plan/repository/PlanRepository.java
+++ b/src/main/java/com/bready/server/plan/repository/PlanRepository.java
@@ -1,9 +1,11 @@
 package com.bready.server.plan.repository;
 
 import com.bready.server.plan.domain.Plan;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -17,28 +19,32 @@ public interface PlanRepository extends JpaRepository<Plan, Long> {
 
     interface PlanSwitchStatsRow {
         Long getPlanId();
+
         String getPlanTitle();
+
         LocalDate getPlanDate();
+
         String getRegion();
+
         Long getTotalSwitches();
     }
 
     /*
     @Query("""
-        select
-            p.id as planId,
-            p.title as planTitle,
-            p.planDate as planDate,
-            p.region as region,
-            count(sl.id) as totalSwitches
-        from Plan p
-        left join Trigger t on t.plan = p
-        left join Decision d on d.trigger = t
-        left join SwitchLog sl on sl.decision = d
-        where p.ownerId = :ownerId
-        group by p.id, p.title, p.planDate, p.region
-        order by p.planDate desc
-    """)
+                select
+                    p.id as planId,
+                    p.title as planTitle,
+                    p.planDate as planDate,
+                    p.region as region,
+                    count(sl.id) as totalSwitches
+                from Plan p
+                left join Trigger t on t.plan = p
+                left join Decision d on d.trigger = t
+                left join SwitchLog sl on sl.decision = d
+                where p.ownerId = :ownerId
+                group by p.id, p.title, p.planDate, p.region
+                order by p.planDate desc
+            """)
     List<PlanSwitchStatsRow> findPlanSwitchStats(
             @Param("ownerId") Long ownerId,
             Pageable pageable
@@ -46,22 +52,22 @@ public interface PlanRepository extends JpaRepository<Plan, Long> {
      */
 
     @Query("""
-        select p
-        from Plan p
-        where p.id = :planId
-          and p.ownerId = :ownerId
-    """)
+                select p
+                from Plan p
+                where p.id = :planId
+                  and p.ownerId = :ownerId
+            """)
     Optional<Plan> findByIdAndOwnerId(@Param("planId") Long planId, @Param("ownerId") Long ownerId);
 
     @Query("""
-        select count(p)
-        from Plan p
-        where p.ownerId = :ownerId
-    """)
+                select count(p)
+                from Plan p
+                where p.ownerId = :ownerId
+            """)
     long countByOwnerId(@Param("ownerId") Long ownerId);
 
+    // 조회용 - 락 없음
     Optional<Plan> findByIdAndDeletedAtIsNull(Long id);
-
 
     @Query(value = """
     SELECT
@@ -88,5 +94,16 @@ public interface PlanRepository extends JpaRepository<Plan, Long> {
             @Param("ownerId") Long ownerId,
             @Param("limit") int limit
     );
+
+    // 락 전용 - 카테고리 추가(addCategory)에서만 사용
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("""
+    select p
+    from Plan p
+    where p.id = :id
+      and p.deletedAt is null
+""")
+    Optional<Plan> findByIdAndDeletedAtIsNullForUpdate(@Param("id") Long id);
+
 
 }

--- a/src/main/java/com/bready/server/plan/repository/PlanRepository.java
+++ b/src/main/java/com/bready/server/plan/repository/PlanRepository.java
@@ -63,6 +63,7 @@ public interface PlanRepository extends JpaRepository<Plan, Long> {
                 select count(p)
                 from Plan p
                 where p.ownerId = :ownerId
+                            and p.deletedAt is null
             """)
     long countByOwnerId(@Param("ownerId") Long ownerId);
 

--- a/src/main/java/com/bready/server/plan/service/PlanCategoryService.java
+++ b/src/main/java/com/bready/server/plan/service/PlanCategoryService.java
@@ -108,7 +108,7 @@ public class PlanCategoryService {
                 .orElseThrow(() -> new ApplicationException(PlanErrorCase.PLAN_NOT_FOUND));
 
         if (!plan.getOwnerId().equals(userId)) {
-            throw new ApplicationException(PlanErrorCase.PLAN_ACCESS_DENIED);
+            throw new ApplicationException(CategoryErrorCase.CATEGORY_ACCESS_DENIED);
         }
 
         List<PlanCategoryOrderUpdateRequest.OrderItem> orders = request.getOrders();

--- a/src/main/java/com/bready/server/plan/service/PlanCategoryService.java
+++ b/src/main/java/com/bready/server/plan/service/PlanCategoryService.java
@@ -175,7 +175,7 @@ public class PlanCategoryService {
 
         return PlanCategoryOrderUpdateResponse.builder()
                 .planId(planId)
-                .updatedAt(LocalDateTime.now())
+                .updatedAt(plan.getUpdatedAt())
                 .build();
     }
 }

--- a/src/main/java/com/bready/server/plan/service/PlanCategoryService.java
+++ b/src/main/java/com/bready/server/plan/service/PlanCategoryService.java
@@ -3,9 +3,7 @@ package com.bready.server.plan.service;
 import com.bready.server.global.exception.ApplicationException;
 import com.bready.server.plan.domain.Plan;
 import com.bready.server.plan.domain.PlanCategory;
-import com.bready.server.plan.dto.PlanCategoryCreateRequest;
-import com.bready.server.plan.dto.PlanCategoryCreateResponse;
-import com.bready.server.plan.dto.PlanCategoryDeleteResponse;
+import com.bready.server.plan.dto.*;
 import com.bready.server.plan.exception.CategoryErrorCase;
 import com.bready.server.plan.exception.PlanErrorCase;
 import com.bready.server.plan.repository.PlanCategoryRepository;
@@ -13,6 +11,12 @@ import com.bready.server.plan.repository.PlanRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -72,6 +76,70 @@ public class PlanCategoryService {
                 .planId(planId)
                 .planCategoryId(planCategoryId)
                 .deletedAt(category.getDeletedAt())
+                .build();
+    }
+
+
+    @Transactional
+    public PlanCategoryOrderUpdateResponse updateCategoryOrder(
+            Long userId,
+            Long planId,
+            PlanCategoryOrderUpdateRequest request
+    ) {
+
+        Plan plan = planRepository.findByIdAndDeletedAtIsNull(planId)
+                .orElseThrow(() -> new ApplicationException(PlanErrorCase.PLAN_NOT_FOUND));
+
+        if (!plan.getOwnerId().equals(userId)) {
+            throw new ApplicationException(PlanErrorCase.PLAN_ACCESS_DENIED);
+        }
+
+        List<PlanCategoryOrderUpdateRequest.OrderItem> orders = request.getOrders();
+        if (orders == null || orders.isEmpty()) {
+            throw new ApplicationException(CategoryErrorCase.INVALID_ORDERS);
+        }
+
+        // 중복, 누락 검증
+        Set<Long> ids = orders.stream()
+                .map(PlanCategoryOrderUpdateRequest.OrderItem::getPlanCategoryId)
+                .collect(Collectors.toSet());
+
+        if (ids.size() != orders.size()) {
+            throw new ApplicationException(CategoryErrorCase.INVALID_ORDERS);
+        }
+
+        // plan 소속 + soft delete 차단 일괄 조회
+        List<PlanCategory> categories = planCategoryRepository.findAllByPlan_IdAndDeletedAtIsNullOrderBySequenceAsc(planId);
+
+        if (categories.size() != orders.size()) {
+            throw new ApplicationException(CategoryErrorCase.INVALID_ORDERS);
+        }
+
+        Set<Long> categoryIds = categories.stream()
+                .map(PlanCategory::getId)
+                .collect(Collectors.toSet());
+
+        if (!categoryIds.equals(ids)) {
+            throw new ApplicationException(CategoryErrorCase.INVALID_ORDERS);
+        }
+
+        Map<Long, Integer> sequenceMap = orders.stream()
+                .collect(Collectors.toMap(
+                        PlanCategoryOrderUpdateRequest.OrderItem::getPlanCategoryId,
+                        PlanCategoryOrderUpdateRequest.OrderItem::getSequence
+                ));
+
+        for (PlanCategory category : categories) {
+            Integer seq = sequenceMap.get(category.getId());
+            if (seq == null || seq < 1) {
+                throw new ApplicationException(CategoryErrorCase.INVALID_SEQUENCE);
+            }
+            category.updateSequence(seq);
+        }
+
+        return PlanCategoryOrderUpdateResponse.builder()
+                .planId(planId)
+                .updatedAt(LocalDateTime.now())
                 .build();
     }
 }

--- a/src/main/java/com/bready/server/plan/service/PlanCategoryService.java
+++ b/src/main/java/com/bready/server/plan/service/PlanCategoryService.java
@@ -9,12 +9,10 @@ import com.bready.server.plan.exception.PlanErrorCase;
 import com.bready.server.plan.repository.PlanCategoryRepository;
 import com.bready.server.plan.repository.PlanRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -30,43 +28,32 @@ public class PlanCategoryService {
     @Transactional
     public PlanCategoryCreateResponse addCategory(Long userId, Long planId, PlanCategoryCreateRequest request) {
 
-        Plan plan = planRepository.findByIdAndDeletedAtIsNull(planId)
+        Plan plan = planRepository.findByIdAndDeletedAtIsNullForUpdate(planId)
                 .orElseThrow(() -> new ApplicationException(PlanErrorCase.PLAN_NOT_FOUND));
 
         if (!plan.getOwnerId().equals(userId)) {
             throw new ApplicationException(CategoryErrorCase.CATEGORY_ACCESS_DENIED);
         }
 
-        for (int attempt = 0; attempt < 3; attempt++) {
-            PlanCategory last = planCategoryRepository
-                    .findLastByPlanIdForUpdate(planId, PageRequest.of(0, 1))
-                    .stream()
-                    .findFirst()
-                    .orElse(null);
+        PlanCategory last = planCategoryRepository
+                .findLastByPlanId(planId, PageRequest.of(0, 1))
+                .stream()
+                .findFirst()
+                .orElse(null);
 
-            int nextSequence = (last == null) ? 1 : last.getSequence() + 1;
+        int nextSequence = (last == null) ? 1 : last.getSequence() + 1;
 
-            try {
-                PlanCategory saved = planCategoryRepository.save(
-                        PlanCategory.create(plan, request.getCategoryType(), nextSequence)
-                );
+        PlanCategory saved = planCategoryRepository.save(
+                PlanCategory.create(plan, request.getCategoryType(), nextSequence)
+        );
 
-                return PlanCategoryCreateResponse.builder()
-                        .planCategoryId(saved.getId())
-                        .planId(plan.getId())
-                        .categoryType(saved.getCategoryType())
-                        .sequence(saved.getSequence())
-                        .createdAt(saved.getCreatedAt())
-                        .build();
-            } catch (DataIntegrityViolationException e) {
-                // 마지막 시도에 실패 처리
-                if (attempt == 2) {
-                    throw e;
-                }
-            }
-        }
-
-        throw new IllegalStateException("unreachable");
+        return PlanCategoryCreateResponse.builder()
+                .planCategoryId(saved.getId())
+                .planId(plan.getId())
+                .categoryType(saved.getCategoryType())
+                .sequence(saved.getSequence())
+                .createdAt(saved.getCreatedAt())
+                .build();
 
     }
 

--- a/src/main/java/com/bready/server/plan/service/PlanCategoryService.java
+++ b/src/main/java/com/bready/server/plan/service/PlanCategoryService.java
@@ -35,13 +35,11 @@ public class PlanCategoryService {
             throw new ApplicationException(CategoryErrorCase.CATEGORY_ACCESS_DENIED);
         }
 
-        Integer sequence = request.getSequence();
-        if (sequence == null || sequence < 1) {
-            throw new ApplicationException(CategoryErrorCase.INVALID_SEQUENCE);
-        }
+        Integer maxSeq = planCategoryRepository.findMaxSequenceByPlanId(planId);
+        int nextSequence = maxSeq + 1;
 
         PlanCategory saved = planCategoryRepository.save(
-                PlanCategory.create(plan, request.getCategoryType(), sequence)
+                PlanCategory.create(plan, request.getCategoryType(), nextSequence)
         );
 
         return PlanCategoryCreateResponse.builder()

--- a/src/main/java/com/bready/server/plan/service/PlanCategoryService.java
+++ b/src/main/java/com/bready/server/plan/service/PlanCategoryService.java
@@ -95,9 +95,6 @@ public class PlanCategoryService {
         }
 
         List<PlanCategoryOrderUpdateRequest.OrderItem> orders = request.getOrders();
-        if (orders == null || orders.isEmpty()) {
-            throw new ApplicationException(CategoryErrorCase.INVALID_ORDERS);
-        }
 
         // 중복, 누락 검증
         Set<Long> ids = orders.stream()
@@ -123,6 +120,22 @@ public class PlanCategoryService {
             throw new ApplicationException(CategoryErrorCase.INVALID_ORDERS);
         }
 
+        int n = orders.size();
+
+        Set<Integer> seqSet = orders.stream()
+                .map(PlanCategoryOrderUpdateRequest.OrderItem::getSequence)
+                .collect(Collectors.toSet());
+
+        if (seqSet.size() != n) {
+            throw new ApplicationException(CategoryErrorCase.INVALID_SEQUENCE);
+        }
+
+        for (int i = 1; i <= n; i++) {
+            if (!seqSet.contains(i)) {
+                throw new ApplicationException(CategoryErrorCase.INVALID_SEQUENCE);
+            }
+        }
+
         Map<Long, Integer> sequenceMap = orders.stream()
                 .collect(Collectors.toMap(
                         PlanCategoryOrderUpdateRequest.OrderItem::getPlanCategoryId,
@@ -131,9 +144,15 @@ public class PlanCategoryService {
 
         for (PlanCategory category : categories) {
             Integer seq = sequenceMap.get(category.getId());
-            if (seq == null || seq < 1) {
+
+            if (seq == null) {
+                throw new ApplicationException(CategoryErrorCase.INVALID_ORDERS);
+            }
+
+            if (seq < 1) {
                 throw new ApplicationException(CategoryErrorCase.INVALID_SEQUENCE);
             }
+
             category.updateSequence(seq);
         }
 

--- a/src/main/java/com/bready/server/plan/service/PlanCategoryService.java
+++ b/src/main/java/com/bready/server/plan/service/PlanCategoryService.java
@@ -91,7 +91,7 @@ public class PlanCategoryService {
             PlanCategoryOrderUpdateRequest request
     ) {
 
-        Plan plan = planRepository.findByIdAndDeletedAtIsNull(planId)
+        Plan plan = planRepository.findByIdAndDeletedAtIsNullForUpdate(planId)
                 .orElseThrow(() -> new ApplicationException(PlanErrorCase.PLAN_NOT_FOUND));
 
         if (!plan.getOwnerId().equals(userId)) {

--- a/src/main/java/com/bready/server/plan/service/PlanCategoryService.java
+++ b/src/main/java/com/bready/server/plan/service/PlanCategoryService.java
@@ -13,6 +13,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -162,7 +163,7 @@ public class PlanCategoryService {
 
         return PlanCategoryOrderUpdateResponse.builder()
                 .planId(planId)
-                .updatedAt(plan.getUpdatedAt())
+                .updatedAt(LocalDateTime.now())
                 .build();
     }
 }

--- a/src/main/java/com/bready/server/plan/service/PlanCategoryService.java
+++ b/src/main/java/com/bready/server/plan/service/PlanCategoryService.java
@@ -1,0 +1,50 @@
+package com.bready.server.plan.service;
+
+import com.bready.server.global.exception.ApplicationException;
+import com.bready.server.plan.domain.Plan;
+import com.bready.server.plan.domain.PlanCategory;
+import com.bready.server.plan.dto.PlanCategoryCreateRequest;
+import com.bready.server.plan.dto.PlanCategoryCreateResponse;
+import com.bready.server.plan.exception.CategoryErrorCase;
+import com.bready.server.plan.exception.PlanErrorCase;
+import com.bready.server.plan.repository.PlanCategoryRepository;
+import com.bready.server.plan.repository.PlanRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class PlanCategoryService {
+
+    private final PlanRepository planRepository;
+    private final PlanCategoryRepository planCategoryRepository;
+
+    @Transactional
+    public PlanCategoryCreateResponse addCategory(Long userId, Long planId, PlanCategoryCreateRequest request) {
+
+        Plan plan = planRepository.findByIdAndDeletedAtIsNull(planId)
+                .orElseThrow(() -> new ApplicationException(PlanErrorCase.PLAN_NOT_FOUND));
+
+        if (!plan.getOwnerId().equals(userId)) {
+            throw new ApplicationException(CategoryErrorCase.CATEGORY_ACCESS_DENIED);
+        }
+
+        Integer sequence = request.getSequence();
+        if (sequence == null || sequence < 1) {
+            throw new ApplicationException(CategoryErrorCase.INVALID_SEQUENCE);
+        }
+
+        PlanCategory saved = planCategoryRepository.save(
+                PlanCategory.create(plan, request.getCategoryType(), sequence)
+        );
+
+        return PlanCategoryCreateResponse.builder()
+                .planCategoryId(saved.getId())
+                .planId(plan.getId())
+                .categoryType(saved.getCategoryType())
+                .sequence(saved.getSequence())
+                .createdAt(saved.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/bready/server/plan/service/PlanCategoryService.java
+++ b/src/main/java/com/bready/server/plan/service/PlanCategoryService.java
@@ -9,6 +9,8 @@ import com.bready.server.plan.exception.PlanErrorCase;
 import com.bready.server.plan.repository.PlanCategoryRepository;
 import com.bready.server.plan.repository.PlanRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -35,20 +37,37 @@ public class PlanCategoryService {
             throw new ApplicationException(CategoryErrorCase.CATEGORY_ACCESS_DENIED);
         }
 
-        Integer maxSeq = planCategoryRepository.findMaxSequenceByPlanId(planId);
-        int nextSequence = maxSeq + 1;
+        for (int attempt = 0; attempt < 3; attempt++) {
+            PlanCategory last = planCategoryRepository
+                    .findLastByPlanIdForUpdate(planId, PageRequest.of(0, 1))
+                    .stream()
+                    .findFirst()
+                    .orElse(null);
 
-        PlanCategory saved = planCategoryRepository.save(
-                PlanCategory.create(plan, request.getCategoryType(), nextSequence)
-        );
+            int nextSequence = (last == null) ? 1 : last.getSequence() + 1;
 
-        return PlanCategoryCreateResponse.builder()
-                .planCategoryId(saved.getId())
-                .planId(plan.getId())
-                .categoryType(saved.getCategoryType())
-                .sequence(saved.getSequence())
-                .createdAt(saved.getCreatedAt())
-                .build();
+            try {
+                PlanCategory saved = planCategoryRepository.save(
+                        PlanCategory.create(plan, request.getCategoryType(), nextSequence)
+                );
+
+                return PlanCategoryCreateResponse.builder()
+                        .planCategoryId(saved.getId())
+                        .planId(plan.getId())
+                        .categoryType(saved.getCategoryType())
+                        .sequence(saved.getSequence())
+                        .createdAt(saved.getCreatedAt())
+                        .build();
+            } catch (DataIntegrityViolationException e) {
+                // 마지막 시도에 실패 처리
+                if (attempt == 2) {
+                    throw e;
+                }
+            }
+        }
+
+        throw new IllegalStateException("unreachable");
+
     }
 
     @Transactional

--- a/src/main/java/com/bready/server/plan/service/PlanCategoryService.java
+++ b/src/main/java/com/bready/server/plan/service/PlanCategoryService.java
@@ -64,7 +64,7 @@ public class PlanCategoryService {
             Long planId,
             Long planCategoryId
     ) {
-        Plan plan = planRepository.findByIdAndDeletedAtIsNull(planId)
+        Plan plan = planRepository.findByIdAndDeletedAtIsNullForUpdate(planId)
                 .orElseThrow(() -> new ApplicationException(PlanErrorCase.PLAN_NOT_FOUND));
 
         if (!plan.getOwnerId().equals(userId)) {

--- a/src/main/java/com/bready/server/plan/service/PlanCategoryService.java
+++ b/src/main/java/com/bready/server/plan/service/PlanCategoryService.java
@@ -5,6 +5,7 @@ import com.bready.server.plan.domain.Plan;
 import com.bready.server.plan.domain.PlanCategory;
 import com.bready.server.plan.dto.PlanCategoryCreateRequest;
 import com.bready.server.plan.dto.PlanCategoryCreateResponse;
+import com.bready.server.plan.dto.PlanCategoryDeleteResponse;
 import com.bready.server.plan.exception.CategoryErrorCase;
 import com.bready.server.plan.exception.PlanErrorCase;
 import com.bready.server.plan.repository.PlanCategoryRepository;
@@ -45,6 +46,32 @@ public class PlanCategoryService {
                 .categoryType(saved.getCategoryType())
                 .sequence(saved.getSequence())
                 .createdAt(saved.getCreatedAt())
+                .build();
+    }
+
+    @Transactional
+    public PlanCategoryDeleteResponse deleteCategory(
+            Long userId,
+            Long planId,
+            Long planCategoryId
+    ) {
+        Plan plan = planRepository.findByIdAndDeletedAtIsNull(planId)
+                .orElseThrow(() -> new ApplicationException(PlanErrorCase.PLAN_NOT_FOUND));
+
+        if (!plan.getOwnerId().equals(userId)) {
+            throw new ApplicationException(CategoryErrorCase.CATEGORY_ACCESS_DENIED);
+        }
+
+        PlanCategory category = planCategoryRepository
+                .findByIdAndPlan_IdAndDeletedAtIsNull(planCategoryId, planId)
+                .orElseThrow(() -> new ApplicationException(CategoryErrorCase.CATEGORY_NOT_FOUND));
+
+        category.softDelete();
+
+        return PlanCategoryDeleteResponse.builder()
+                .planId(planId)
+                .planCategoryId(planCategoryId)
+                .deletedAt(category.getDeletedAt())
                 .build();
     }
 }

--- a/src/main/java/com/bready/server/plan/service/PlanService.java
+++ b/src/main/java/com/bready/server/plan/service/PlanService.java
@@ -4,6 +4,7 @@ import com.bready.server.global.exception.ApplicationException;
 import com.bready.server.plan.domain.Plan;
 import com.bready.server.plan.dto.*;
 import com.bready.server.plan.exception.PlanErrorCase;
+import com.bready.server.plan.repository.PlanCategoryRepository;
 import com.bready.server.plan.repository.PlanRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -20,6 +21,7 @@ import java.util.List;
 public class PlanService {
 
     private final PlanRepository planRepository;
+    private final PlanCategoryRepository planCategoryRepository;
 
     @Transactional
     public PlanCreateResponse createPlan(Long userId, PlanCreateRequest request) {
@@ -75,8 +77,19 @@ public class PlanService {
                 .updatedAt(plan.getUpdatedAt())
                 .build();
 
+        List<PlanCategoryItemDto> categories = planCategoryRepository
+                .findAllByPlan_IdAndDeletedAtIsNullOrderBySequenceAsc(planId)
+                .stream()
+                .map(pc -> PlanCategoryItemDto.builder()
+                        .planCategoryId(pc.getId())
+                        .categoryType(pc.getCategoryType())
+                        .sequence(pc.getSequence())
+                        .build())
+                .toList();
+
         return PlanDetailResponse.builder()
                 .plan(planDto)
+                .categories(categories)
                 .build();
     }
 

--- a/src/main/java/com/bready/server/trigger/service/TriggerService.java
+++ b/src/main/java/com/bready/server/trigger/service/TriggerService.java
@@ -30,7 +30,7 @@ public class TriggerService {
     public TriggerCreateResponse createTrigger(TriggerCreateRequest request) {
 
         PlanCategory category = planCategoryRepository
-                .findByIdAndPlan_Id(request.categoryId(), request.planId())
+                .findByIdAndPlan_IdAndDeletedAtIsNull(request.categoryId(), request.planId())
                 .orElseThrow(() ->
                         ApplicationException.from(TriggerErrorCase.PLAN_OR_CATEGORY_NOT_FOUND)
                 );

--- a/src/test/java/com/bready/server/place/service/PlaceCandidateServiceTest.java
+++ b/src/test/java/com/bready/server/place/service/PlaceCandidateServiceTest.java
@@ -72,7 +72,7 @@ class PlaceCandidateServiceTest {
         when(savedCandidate.getId()).thenReturn(100L);
         when(savedCandidate.getCreatedAt()).thenReturn(LocalDateTime.now());
 
-        when(planCategoryRepository.findByIdAndPlan_Id(10L, 1L))
+        when(planCategoryRepository.findByIdAndPlan_IdAndDeletedAtIsNull(10L, 1L))
                 .thenReturn(Optional.of(category));
 
         when(placePersistenceService.getOrCreate(request))
@@ -105,7 +105,7 @@ class PlaceCandidateServiceTest {
         PlanCategory category = mock(PlanCategory.class);
         Place place = mock(Place.class);
 
-        when(planCategoryRepository.findByIdAndPlan_Id(10L, 1L))
+        when(planCategoryRepository.findByIdAndPlan_IdAndDeletedAtIsNull(10L, 1L))
                 .thenReturn(Optional.of(category));
 
         when(placePersistenceService.getOrCreate(request))

--- a/src/test/java/com/bready/server/trigger/service/TriggerServiceTest.java
+++ b/src/test/java/com/bready/server/trigger/service/TriggerServiceTest.java
@@ -53,7 +53,7 @@ class TriggerServiceTest {
         CategoryState state = mock(CategoryState.class);
         Trigger trigger = mock(Trigger.class);
 
-        given(planCategoryRepository.findByIdAndPlan_Id(categoryId, planId))
+        given(planCategoryRepository.findByIdAndPlan_IdAndDeletedAtIsNull(categoryId, planId))
                 .willReturn(Optional.of(category));
 
         given(category.getPlan()).willReturn(plan);
@@ -83,7 +83,7 @@ class TriggerServiceTest {
     void createTrigger_categoryStateNotFound() {
         PlanCategory category = mock(PlanCategory.class);
 
-        given(planCategoryRepository.findByIdAndPlan_Id(1L, 1L))
+        given(planCategoryRepository.findByIdAndPlan_IdAndDeletedAtIsNull(1L, 1L))
                 .willReturn(Optional.of(category));
 
         given(categoryStateRepository.findByCategory_Id(any()))
@@ -102,7 +102,7 @@ class TriggerServiceTest {
     @Test
     @DisplayName("트리거 생성 실패 - 플랜/카테고리 없음")
     void createTrigger_planOrCategoryNotFound() {
-        given(planCategoryRepository.findByIdAndPlan_Id(any(), any()))
+        given(planCategoryRepository.findByIdAndPlan_IdAndDeletedAtIsNull(any(), any()))
                 .willReturn(Optional.empty());
 
         assertThatThrownBy(() ->


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #55 


## 📝 작업 내용

- 카테고리 추가
- 카테고리 삭제 (soft delete)
- 카테고리 순서 변경 (전체 재정렬 방식, 연속 sequence 검증)
- 플랜 상세 조회 시 카테고리 목록 연동


## 🖼️ 스크린샷 (선택)
### 카테고리 추가 성공 응답
<img width="560" height="402" alt="image" src="https://github.com/user-attachments/assets/3bfc3d2c-b5a1-4a35-b48d-5e4c9df74cf2" />

### 카테고리 삭제 성공 응답
<img width="538" height="341" alt="image" src="https://github.com/user-attachments/assets/1500140b-4f60-4f79-aa58-49c41121e710" />

### 순서 변경 성공 응답
<img width="570" height="352" alt="image" src="https://github.com/user-attachments/assets/7fb7778d-0efc-4d4a-8b73-922483fe535d" />

## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특히 봐주었으면 하는 부분이 있다면 작성해주세요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 플랜 내 카테고리 관리 REST API 추가: 카테고리 생성, 소프트 삭제, 순서 변경
  * 플랜 상세화면에 카테고리 목록 노출
* **유효성 및 권한 검증**
  * 순서·중복·누락 검증 및 권한 검증 강화
  * 소프트 삭제 적용으로 조회/검증 기준 강화
  * 표준화된 오류 코드/메시지 추가
* **신뢰성 개선**
  * 순서 변경 시 동시성 안전성(잠금 기반 처리) 개선
* **테스트**
  * 조회 조건 변경에 따른 관련 테스트 업데이트
<!-- end of auto-generated comment: release notes by coderabbit.ai -->