### PR TITLE
[refactor] Materialized Plan Stats 도입 (통계 조회 2차 성능 개선)

### DIFF
--- a/db/index/2026-02-12-add-index.sql
+++ b/db/index/2026-02-12-add-index.sql
@@ -1,0 +1,12 @@
+ALTER TABLE plan_stats
+    ADD CONSTRAINT uk_plan_stats_plan_period
+        UNIQUE (plan_id, period);
+
+CREATE INDEX idx_plan_stats_period_plan
+    ON plan_stats(period, plan_id);
+
+CREATE INDEX idx_triggers_plan_occurred
+    ON triggers(plan_id, occurred_at);
+
+CREATE INDEX idx_switch_logs_created
+    ON switch_logs(created_at);

--- a/performance-test/k6/scripts/compare.js
+++ b/performance-test/k6/scripts/compare.js
@@ -1,0 +1,82 @@
+import http from "k6/http";
+import { check, sleep } from "k6";
+
+const BASE_URL = __ENV.BASE_URL || "http://host.docker.internal:8080";
+const TOKEN = __ENV.ACCESS_TOKEN;
+
+export const options = {
+    scenarios: {
+
+        // JOIN
+        join_test: {
+            executor: "ramping-vus",
+            exec: "joinScenario",
+            stages: [
+                { duration: "30s", target: 30 },
+                { duration: "1m", target: 80 },
+                { duration: "30s", target: 0 },
+            ],
+        },
+
+        // Materialized
+        materialized_test: {
+            executor: "ramping-vus",
+            exec: "materializedScenario",
+            startTime: "10s", // 살짝 늦게 시작 (워밍업 방지)
+            stages: [
+                { duration: "30s", target: 30 },
+                { duration: "1m", target: 80 },
+                { duration: "30s", target: 0 },
+            ],
+        },
+    },
+
+    thresholds: {
+
+        "http_req_failed{type:join}": ["rate<0.01"],
+        "http_req_failed{type:materialized}": ["rate<0.01"],
+
+        "http_req_duration{type:join}": ["p(95)<2500"],
+        "http_req_duration{type:materialized}": ["p(95)<200"],
+    },
+};
+
+// JOIN
+export function joinScenario() {
+
+    const res = http.get(
+        `${BASE_URL}/api/v1/stats/plans/join?period=WEEK&limit=10`,
+        {
+            headers: {
+                Authorization: `Bearer ${TOKEN}`,
+            },
+            tags: { type: "join" },
+        }
+    );
+
+    check(res, {
+        "JOIN 200": (r) => r.status === 200,
+    });
+
+    sleep(1);
+}
+
+// Materialized
+export function materializedScenario() {
+
+    const res = http.get(
+        `${BASE_URL}/api/v1/stats/plans/materialized?period=WEEK&limit=10`,
+        {
+            headers: {
+                Authorization: `Bearer ${TOKEN}`,
+            },
+            tags: { type: "materialized" },
+        }
+    );
+
+    check(res, {
+        "MAT 200": (r) => r.status === 200,
+    });
+
+    sleep(1);
+}

--- a/performance-test/sql/build_plan_stats.sql
+++ b/performance-test/sql/build_plan_stats.sql
@@ -1,0 +1,154 @@
+USE bready;
+
+
+--plan_stats 비우기
+DELETE FROM plan_stats;
+
+
+-- WEEK / MONTH / ALL 통계 재빌드
+-- triggers.occurred_at 기준으로 기간 필터
+-- switches는 switch_logs.created_at 기준으로 기간 필터
+
+/* WEEK (최근 7일) */
+INSERT INTO plan_stats (
+    plan_id,
+    period,
+    total_triggers,
+    total_switches,
+    reliability_score,
+    created_at,
+    updated_at
+)
+SELECT
+    p.id AS plan_id,
+    'WEEK' AS period,
+
+    /* total_triggers */
+    (
+        SELECT COUNT(*)
+        FROM triggers t
+        WHERE t.plan_id = p.id
+          AND t.occurred_at >= NOW() - INTERVAL 7 DAY
+    ) AS total_triggers,
+
+    /* total_switches */
+    (
+        SELECT COUNT(*)
+        FROM switch_logs sl
+        JOIN decisions d ON d.id = sl.decision_id
+        JOIN triggers  t ON t.id = d.trigger_id
+        WHERE t.plan_id = p.id
+        AND sl.created_at >= NOW() - INTERVAL 7 DAY
+    ) AS total_switches,
+
+
+    ROUND(
+        (1 - (
+            (
+                SELECT COUNT(*)
+                FROM switch_logs sl
+                JOIN decisions d ON d.id = sl.decision_id
+                JOIN triggers  t ON t.id = d.trigger_id
+                WHERE t.plan_id = p.id
+                  AND sl.created_at >= NOW() - INTERVAL 7 DAY
+    ) / GREATEST(
+        (
+            SELECT COUNT(*)
+            FROM triggers t
+            WHERE t.plan_id = p.id
+              AND t.occurred_at >= NOW() - INTERVAL 7 DAY
+        ), 1
+       )
+    )) * 100
+    , 2) AS reliability_score,
+
+    NOW(),
+    NOW()
+FROM plans p;
+
+
+/* MONTH (최근 1개월) */
+INSERT INTO plan_stats (
+    plan_id,
+    period,
+    total_triggers,
+    total_switches,
+    reliability_score,
+    created_at,
+    updated_at
+)
+SELECT
+    p.id AS plan_id,
+    'MONTH' AS period,
+
+    (
+        SELECT COUNT(*)
+        FROM triggers t
+        WHERE t.plan_id = p.id
+          AND t.occurred_at >= NOW() - INTERVAL 1 MONTH
+        ) AS total_triggers,
+
+    (
+        SELECT COUNT(*)
+        FROM switch_logs sl
+        JOIN decisions d ON d.id = sl.decision_id
+        JOIN triggers  t ON t.id = d.trigger_id
+        WHERE t.plan_id = p.id
+          AND sl.created_at >= NOW() - INTERVAL 1 MONTH
+    ) AS total_switches,
+
+    ROUND(
+        (1 - (
+            (
+                SELECT COUNT(*)
+                FROM switch_logs sl
+                JOIN decisions d ON d.id = sl.decision_id
+                JOIN triggers  t ON t.id = d.trigger_id
+                WHERE t.plan_id = p.id
+                  AND sl.created_at >= NOW() - INTERVAL 1 MONTH
+            ) / GREATEST(
+                (
+                    SELECT COUNT(*)
+                    FROM triggers t
+                    WHERE t.plan_id = p.id
+                      AND t.occurred_at >= NOW() - INTERVAL 1 MONTH
+                ), 1
+            )
+        )) * 100
+    , 2) AS reliability_score,
+
+    NOW(),
+    NOW()
+FROM plans p;
+
+
+/* ALL (전체) -> JOIN으로 한 번에 계산 (기간 없음) */
+INSERT INTO plan_stats (
+    plan_id,
+    period,
+    total_triggers,
+    total_switches,
+    reliability_score,
+    created_at,
+    updated_at
+)
+SELECT
+    p.id AS plan_id,
+    'ALL' AS period,
+    COUNT(DISTINCT t.id) AS total_triggers,
+    COUNT(DISTINCT sl.id) AS total_switches,
+    ROUND((1 - (COUNT(DISTINCT sl.id) / GREATEST(COUNT(DISTINCT t.id), 1))) * 100, 2) AS reliability_score,
+    NOW(),
+    NOW()
+FROM plans p
+         LEFT JOIN triggers t ON t.plan_id = p.id
+         LEFT JOIN decisions d ON d.trigger_id = t.id
+         LEFT JOIN switch_logs sl ON sl.decision_id = d.id
+GROUP BY p.id;
+
+-- 옵티마이저 통계 갱신
+ANALYZE TABLE plan_stats;
+
+-- 확인
+SELECT period, COUNT(*) AS rows_count FROM plan_stats GROUP BY period;
+SELECT * FROM plan_stats LIMIT 5;

--- a/src/main/java/com/bready/server/global/config/AsyncConfig.java
+++ b/src/main/java/com/bready/server/global/config/AsyncConfig.java
@@ -1,0 +1,9 @@
+package com.bready.server.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+}

--- a/src/main/java/com/bready/server/stats/domain/PlanStats.java
+++ b/src/main/java/com/bready/server/stats/domain/PlanStats.java
@@ -20,8 +20,9 @@ public class PlanStats extends BaseEntity {
     @Column(name = "plan_id", nullable = false)
     private Long planId;
 
+    @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    private String period;
+    private StatsPeriod period;
 
     @Column(name = "total_triggers")
     private Integer totalTriggers;

--- a/src/main/java/com/bready/server/stats/domain/PlanStats.java
+++ b/src/main/java/com/bready/server/stats/domain/PlanStats.java
@@ -10,7 +10,15 @@ import java.math.BigDecimal;
 @Getter
 @NoArgsConstructor
 @Entity
-@Table(name = "plan_stats")
+@Table(
+        name = "plan_stats",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_plan_stats_plan_period",
+                        columnNames = {"plan_id", "period"}
+                )
+        }
+)
 public class PlanStats extends BaseEntity {
 
     @Id
@@ -32,4 +40,30 @@ public class PlanStats extends BaseEntity {
 
     @Column(name = "reliability_score", precision = 5, scale = 2)
     private BigDecimal reliabilityScore;
+
+    public static PlanStats create(
+            Long planId,
+            StatsPeriod period,
+            int totalTriggers,
+            int totalSwitches,
+            BigDecimal reliabilityScore
+    ) {
+        PlanStats stats = new PlanStats();
+        stats.planId = planId;
+        stats.period = period;
+        stats.totalTriggers = totalTriggers;
+        stats.totalSwitches = totalSwitches;
+        stats.reliabilityScore = reliabilityScore;
+        return stats;
+    }
+
+    public void update(
+            int totalTriggers,
+            int totalSwitches,
+            BigDecimal reliabilityScore
+    ) {
+        this.totalTriggers = totalTriggers;
+        this.totalSwitches = totalSwitches;
+        this.reliabilityScore = reliabilityScore;
+    }
 }

--- a/src/main/java/com/bready/server/stats/dto/PlanStatsResponse.java
+++ b/src/main/java/com/bready/server/stats/dto/PlanStatsResponse.java
@@ -10,4 +10,10 @@ public record PlanStatsResponse(
         StatsPeriod period,
         List<PlanStatsItem> items
 ) {
+    public static PlanStatsResponse empty(StatsPeriod period) {
+        return PlanStatsResponse.builder()
+                .period(period)
+                .items(List.of())
+                .build();
+    }
 }

--- a/src/main/java/com/bready/server/stats/event/SwitchLogCreatedEvent.java
+++ b/src/main/java/com/bready/server/stats/event/SwitchLogCreatedEvent.java
@@ -1,0 +1,5 @@
+package com.bready.server.stats.event;
+
+public record SwitchLogCreatedEvent(
+        Long planId
+) {}

--- a/src/main/java/com/bready/server/stats/event/SwitchLogCreatedEvent.java
+++ b/src/main/java/com/bready/server/stats/event/SwitchLogCreatedEvent.java
@@ -1,5 +1,11 @@
 package com.bready.server.stats.event;
 
+import java.util.Objects;
+
 public record SwitchLogCreatedEvent(
         Long planId
-) {}
+) {
+    public SwitchLogCreatedEvent {
+                Objects.requireNonNull(planId, "planId는 null이 될 수 없습니다.");
+    }
+}

--- a/src/main/java/com/bready/server/stats/event/TriggerCreatedEvent.java
+++ b/src/main/java/com/bready/server/stats/event/TriggerCreatedEvent.java
@@ -1,0 +1,5 @@
+package com.bready.server.stats.event;
+
+public record TriggerCreatedEvent(
+        Long planId
+) {}

--- a/src/main/java/com/bready/server/stats/event/TriggerCreatedEvent.java
+++ b/src/main/java/com/bready/server/stats/event/TriggerCreatedEvent.java
@@ -1,5 +1,6 @@
 package com.bready.server.stats.event;
 
-public record TriggerCreatedEvent(
-        Long planId
-) {}
+import java.time.LocalDateTime;
+
+public record TriggerCreatedEvent(Long planId, LocalDateTime occurredAt) {
+}

--- a/src/main/java/com/bready/server/stats/event/TriggerCreatedEvent.java
+++ b/src/main/java/com/bready/server/stats/event/TriggerCreatedEvent.java
@@ -1,6 +1,11 @@
 package com.bready.server.stats.event;
 
 import java.time.LocalDateTime;
+import java.util.Objects;
 
 public record TriggerCreatedEvent(Long planId, LocalDateTime occurredAt) {
+    public TriggerCreatedEvent {
+        Objects.requireNonNull(planId, "planId는 null이 될 수 없습니다.");
+        Objects.requireNonNull(occurredAt, "occurredAt는 null이 될 수 없습니다.");
+    }
 }

--- a/src/main/java/com/bready/server/stats/listener/PlanStatsEventListener.java
+++ b/src/main/java/com/bready/server/stats/listener/PlanStatsEventListener.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 
 @Slf4j
@@ -19,14 +20,14 @@ public class PlanStatsEventListener {
 
     // Switch 발생 → switchCount 변경
     @Async
-    @TransactionalEventListener
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleSwitchCreated(SwitchLogCreatedEvent event) {
         recalculateAll(event.planId());
     }
 
     // Trigger 발생 → triggerCount 변경
     @Async
-    @TransactionalEventListener
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleTriggerCreated(TriggerCreatedEvent event) {
         recalculateAll(event.planId());
     }

--- a/src/main/java/com/bready/server/stats/listener/PlanStatsEventListener.java
+++ b/src/main/java/com/bready/server/stats/listener/PlanStatsEventListener.java
@@ -1,0 +1,4 @@
+package com.bready.server.stats.listener;
+
+public class PlanStatsEventListener {
+}

--- a/src/main/java/com/bready/server/stats/listener/PlanStatsEventListener.java
+++ b/src/main/java/com/bready/server/stats/listener/PlanStatsEventListener.java
@@ -5,10 +5,12 @@ import com.bready.server.stats.event.SwitchLogCreatedEvent;
 import com.bready.server.stats.event.TriggerCreatedEvent;
 import com.bready.server.stats.service.PlanStatsUpdater;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionalEventListener;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class PlanStatsEventListener {
@@ -18,26 +20,24 @@ public class PlanStatsEventListener {
     // Switch 발생 → switchCount 변경
     @Async
     @TransactionalEventListener
-    public void handleSwitchCreated(
-            SwitchLogCreatedEvent event
-    ) {
-        Long planId = event.planId();
-
-        updater.recalculate(planId, StatsPeriod.WEEK);
-        updater.recalculate(planId, StatsPeriod.MONTH);
-        updater.recalculate(planId, StatsPeriod.ALL);
+    public void handleSwitchCreated(SwitchLogCreatedEvent event) {
+        recalculateAll(event.planId());
     }
 
     // Trigger 발생 → triggerCount 변경
     @Async
     @TransactionalEventListener
-    public void handleTriggerCreated(
-            TriggerCreatedEvent event
-    ) {
-        Long planId = event.planId();
+    public void handleTriggerCreated(TriggerCreatedEvent event) {
+        recalculateAll(event.planId());
+    }
 
-        updater.recalculate(planId, StatsPeriod.WEEK);
-        updater.recalculate(planId, StatsPeriod.MONTH);
-        updater.recalculate(planId, StatsPeriod.ALL);
+    private void recalculateAll(Long planId) {
+        for (StatsPeriod period : StatsPeriod.values()) {
+            try {
+                updater.recalculate(planId, period);
+            } catch (Exception e) {
+                log.error("PlanStats 갱신 실패: planId={}, period={}", planId, period, e);
+            }
+        }
     }
 }

--- a/src/main/java/com/bready/server/stats/listener/PlanStatsEventListener.java
+++ b/src/main/java/com/bready/server/stats/listener/PlanStatsEventListener.java
@@ -1,4 +1,43 @@
 package com.bready.server.stats.listener;
 
+import com.bready.server.stats.domain.StatsPeriod;
+import com.bready.server.stats.event.SwitchLogCreatedEvent;
+import com.bready.server.stats.event.TriggerCreatedEvent;
+import com.bready.server.stats.service.PlanStatsUpdater;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
 public class PlanStatsEventListener {
+
+    private final PlanStatsUpdater updater;
+
+    // Switch 발생 → switchCount 변경
+    @Async
+    @TransactionalEventListener
+    public void handleSwitchCreated(
+            SwitchLogCreatedEvent event
+    ) {
+        Long planId = event.planId();
+
+        updater.recalculate(planId, StatsPeriod.WEEK);
+        updater.recalculate(planId, StatsPeriod.MONTH);
+        updater.recalculate(planId, StatsPeriod.ALL);
+    }
+
+    // Trigger 발생 → triggerCount 변경
+    @Async
+    @TransactionalEventListener
+    public void handleTriggerCreated(
+            TriggerCreatedEvent event
+    ) {
+        Long planId = event.planId();
+
+        updater.recalculate(planId, StatsPeriod.WEEK);
+        updater.recalculate(planId, StatsPeriod.MONTH);
+        updater.recalculate(planId, StatsPeriod.ALL);
+    }
 }

--- a/src/main/java/com/bready/server/stats/repository/PlanStatsRepository.java
+++ b/src/main/java/com/bready/server/stats/repository/PlanStatsRepository.java
@@ -1,7 +1,17 @@
 package com.bready.server.stats.repository;
 
 import com.bready.server.stats.domain.PlanStats;
+import com.bready.server.stats.domain.StatsPeriod;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+import java.util.Optional;
+
 public interface PlanStatsRepository extends JpaRepository<PlanStats, Long> {
+    Optional<PlanStats> findByPlanIdAndPeriod(Long planId, StatsPeriod period);
+
+    List<PlanStats> findByPeriodAndPlanIdIn(
+            StatsPeriod period,
+            List<Long> planIds
+    );
 }

--- a/src/main/java/com/bready/server/stats/repository/PlanStatsRepository.java
+++ b/src/main/java/com/bready/server/stats/repository/PlanStatsRepository.java
@@ -5,9 +5,15 @@ import com.bready.server.stats.domain.StatsPeriod;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface PlanStatsRepository extends JpaRepository<PlanStats, Long> {
     List<PlanStats> findByPlanIdIn(List<Long> planIds);
+
+    Optional<PlanStats> findByPlanIdAndPeriod(
+            Long planId,
+            StatsPeriod period
+    );
 
     List<PlanStats> findByPeriodAndPlanIdIn(
             StatsPeriod period,

--- a/src/main/java/com/bready/server/stats/repository/PlanStatsRepository.java
+++ b/src/main/java/com/bready/server/stats/repository/PlanStatsRepository.java
@@ -12,11 +12,6 @@ import java.util.List;
 import java.util.Optional;
 
 public interface PlanStatsRepository extends JpaRepository<PlanStats, Long> {
-    Optional<PlanStats> findByPlanIdAndPeriod(
-            Long planId,
-            StatsPeriod period
-    );
-
     List<PlanStats> findByPeriodAndPlanIdIn(
             StatsPeriod period,
             List<Long> planIds

--- a/src/main/java/com/bready/server/stats/repository/PlanStatsRepository.java
+++ b/src/main/java/com/bready/server/stats/repository/PlanStatsRepository.java
@@ -5,10 +5,9 @@ import com.bready.server.stats.domain.StatsPeriod;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
-import java.util.Optional;
 
 public interface PlanStatsRepository extends JpaRepository<PlanStats, Long> {
-    Optional<PlanStats> findByPlanIdAndPeriod(Long planId, StatsPeriod period);
+    List<PlanStats> findByPlanIdIn(List<Long> planIds);
 
     List<PlanStats> findByPeriodAndPlanIdIn(
             StatsPeriod period,

--- a/src/main/java/com/bready/server/stats/repository/PlanStatsRepository.java
+++ b/src/main/java/com/bready/server/stats/repository/PlanStatsRepository.java
@@ -8,8 +8,6 @@ import java.util.List;
 import java.util.Optional;
 
 public interface PlanStatsRepository extends JpaRepository<PlanStats, Long> {
-    List<PlanStats> findByPlanIdIn(List<Long> planIds);
-
     Optional<PlanStats> findByPlanIdAndPeriod(
             Long planId,
             StatsPeriod period

--- a/src/main/java/com/bready/server/stats/repository/PlanStatsRepository.java
+++ b/src/main/java/com/bready/server/stats/repository/PlanStatsRepository.java
@@ -2,7 +2,11 @@ package com.bready.server.stats.repository;
 
 import com.bready.server.stats.domain.PlanStats;
 import com.bready.server.stats.domain.StatsPeriod;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -16,5 +20,17 @@ public interface PlanStatsRepository extends JpaRepository<PlanStats, Long> {
     List<PlanStats> findByPeriodAndPlanIdIn(
             StatsPeriod period,
             List<Long> planIds
+    );
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("""
+        select ps
+        from PlanStats ps
+        where ps.planId = :planId
+          and ps.period = :period
+    """)
+    Optional<PlanStats> findByPlanIdAndPeriodForUpdate(
+            @Param("planId") Long planId,
+            @Param("period") StatsPeriod period
     );
 }

--- a/src/main/java/com/bready/server/stats/service/PlanStatsMaterializedService.java
+++ b/src/main/java/com/bready/server/stats/service/PlanStatsMaterializedService.java
@@ -1,11 +1,13 @@
 package com.bready.server.stats.service;
 
+import com.bready.server.global.exception.ApplicationException;
 import com.bready.server.plan.domain.Plan;
 import com.bready.server.plan.repository.PlanRepository;
 import com.bready.server.stats.domain.PlanStats;
 import com.bready.server.stats.domain.StatsPeriod;
 import com.bready.server.stats.dto.PlanStatsItem;
 import com.bready.server.stats.dto.PlanStatsResponse;
+import com.bready.server.stats.exception.StatsErrorCase;
 import com.bready.server.stats.repository.PlanStatsRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
@@ -26,12 +28,15 @@ public class PlanStatsMaterializedService {
     private final PlanStatsRepository planStatsRepository;
     private final PlanRepository planRepository;
 
+    private static final int DEFAULT_LIMIT = 20;
+    private static final int MAX_LIMIT = 50;
+
     public PlanStatsResponse getStats(
             Long ownerId,
             StatsPeriod period,
             Integer limit
     ) {
-        int size = limit == null ? 20 : limit;
+        int size = normalizeLimit(limit);
 
         Pageable pageable =
                 PageRequest.of(0, size, Sort.by("planDate").descending());
@@ -79,5 +84,14 @@ public class PlanStatsMaterializedService {
                 .period(period)
                 .items(items)
                 .build();
+    }
+
+
+    private int normalizeLimit(Integer limitParam) {
+        int limit = limitParam == null ? DEFAULT_LIMIT : limitParam;
+        if (limit <= 0 || limit > MAX_LIMIT) {
+            throw ApplicationException.from(StatsErrorCase.INVALID_PARAMETER);
+        }
+        return limit;
     }
 }

--- a/src/main/java/com/bready/server/stats/service/PlanStatsMaterializedService.java
+++ b/src/main/java/com/bready/server/stats/service/PlanStatsMaterializedService.java
@@ -1,11 +1,22 @@
 package com.bready.server.stats.service;
 
+import com.bready.server.plan.domain.Plan;
+import com.bready.server.plan.repository.PlanRepository;
+import com.bready.server.stats.domain.PlanStats;
 import com.bready.server.stats.domain.StatsPeriod;
+import com.bready.server.stats.dto.PlanStatsItem;
 import com.bready.server.stats.dto.PlanStatsResponse;
 import com.bready.server.stats.repository.PlanStatsRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -13,16 +24,60 @@ import org.springframework.transaction.annotation.Transactional;
 public class PlanStatsMaterializedService {
 
     private final PlanStatsRepository planStatsRepository;
+    private final PlanRepository planRepository;
 
     public PlanStatsResponse getStats(
             Long ownerId,
             StatsPeriod period,
             Integer limit
     ) {
+        int size = limit == null ? 20 : limit;
 
-        // 아직 구현 안함 (JOIN 성능 먼저 측정해야 비교 가능.)
-        throw new UnsupportedOperationException(
-                "Materialized stats not implemented yet"
-        );
+        Pageable pageable =
+                PageRequest.of(0, size, Sort.by("planDate").descending());
+
+        List<Plan> plans =
+                planRepository.findAllByOwnerIdAndDeletedAtIsNull(ownerId, pageable)
+                        .getContent();
+
+        if (plans.isEmpty()) {
+            return PlanStatsResponse.empty(period);
+        }
+
+        List<Long> planIds = plans.stream().map(Plan::getId).toList();
+
+        Map<Long, PlanStats> statsMap =
+                planStatsRepository
+                        .findByPeriodAndPlanIdIn(period, planIds)
+                        .stream()
+                        .collect(Collectors.toMap(
+                                PlanStats::getPlanId,
+                                s -> s
+                        ));
+
+        List<PlanStatsItem> items =
+                plans.stream()
+                        .map(plan -> {
+
+                            PlanStats stats = statsMap.get(plan.getId());
+
+                            return PlanStatsItem.builder()
+                                    .planId(plan.getId())
+                                    .planTitle(plan.getTitle())
+                                    .planDate(plan.getPlanDate())
+                                    .region(plan.getRegion())
+                                    .totalSwitches(
+                                            stats == null
+                                                    ? 0L
+                                                    : stats.getTotalSwitches()
+                                    )
+                                    .build();
+                        })
+                        .toList();
+
+        return PlanStatsResponse.builder()
+                .period(period)
+                .items(items)
+                .build();
     }
 }

--- a/src/main/java/com/bready/server/stats/service/PlanStatsUpdater.java
+++ b/src/main/java/com/bready/server/stats/service/PlanStatsUpdater.java
@@ -1,0 +1,83 @@
+package com.bready.server.stats.service;
+
+import com.bready.server.stats.domain.PlanStats;
+import com.bready.server.stats.domain.StatsPeriod;
+import com.bready.server.stats.repository.PlanStatsRepository;
+import com.bready.server.trigger.repository.SwitchLogRepository;
+import com.bready.server.trigger.repository.TriggerRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class PlanStatsUpdater {
+
+    private final PlanStatsRepository planStatsRepository;
+    private final TriggerRepository triggerRepository;
+    private final SwitchLogRepository switchLogRepository;
+
+    public void recalculate(Long planId, StatsPeriod period) {
+
+        LocalDateTime from = resolveFrom(period);
+
+        long triggerCount =
+                triggerRepository.countByPlanIdAndPeriod(planId, from);
+
+        long switchCount =
+                switchLogRepository.countSwitchByPlanIdAndPeriod(planId, from);
+
+        BigDecimal reliability =
+                calculateReliability(triggerCount, switchCount);
+
+        PlanStats stats = planStatsRepository
+                .findByPlanIdAndPeriod(planId, period)
+                .orElseGet(() ->
+                        PlanStats.create(
+                                planId,
+                                period,
+                                0,
+                                0,
+                                BigDecimal.ZERO
+                        )
+                );
+
+        stats.update(
+                (int) triggerCount,
+                (int) switchCount,
+                reliability
+        );
+
+        planStatsRepository.save(stats);
+    }
+
+    private LocalDateTime resolveFrom(StatsPeriod period) {
+        LocalDateTime now = LocalDateTime.now();
+
+        return switch (period) {
+            case WEEK -> now.minusWeeks(1);
+            case MONTH -> now.minusMonths(1);
+            case ALL -> LocalDateTime.MIN;
+        };
+    }
+
+    private BigDecimal calculateReliability(
+            long triggerCount,
+            long switchCount
+    ) {
+        if (triggerCount == 0) {
+            return BigDecimal.valueOf(100);
+        }
+
+        double ratio = 1 - ((double) switchCount / triggerCount);
+
+        return BigDecimal.valueOf(ratio * 100)
+                .setScale(2, RoundingMode.HALF_UP);
+    }
+}
+

--- a/src/main/java/com/bready/server/stats/service/PlanStatsUpdater.java
+++ b/src/main/java/com/bready/server/stats/service/PlanStatsUpdater.java
@@ -6,6 +6,7 @@ import com.bready.server.stats.repository.PlanStatsRepository;
 import com.bready.server.trigger.repository.SwitchLogRepository;
 import com.bready.server.trigger.repository.TriggerRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -36,23 +37,22 @@ public class PlanStatsUpdater {
                 calculateReliability(triggerCount, switchCount);
 
         PlanStats stats = planStatsRepository
-                .findByPlanIdAndPeriod(planId, period)
-                .orElseGet(() ->
-                        PlanStats.create(
-                                planId,
-                                period,
-                                0,
-                                0,
-                                BigDecimal.ZERO
-                        )
-                );
+                                .findByPlanIdAndPeriod(planId, period)
+                                .orElse(null);
 
-        stats.update(
-                (int) triggerCount,
-                (int) switchCount,
-                reliability
-        );
+        if (stats == null) {
+            try {
+                stats = PlanStats.create(planId, period, (int) triggerCount, (int) switchCount, reliability);
+                planStatsRepository.save(stats);
+                return;
+            } catch (DataIntegrityViolationException e) {
+                stats = planStatsRepository
+                        .findByPlanIdAndPeriod(planId, period)
+                        .orElseThrow();
+            }
+        }
 
+        stats.update((int) triggerCount, (int) switchCount, reliability);
         planStatsRepository.save(stats);
     }
 

--- a/src/main/java/com/bready/server/stats/service/PlanStatsUpdater.java
+++ b/src/main/java/com/bready/server/stats/service/PlanStatsUpdater.java
@@ -62,7 +62,7 @@ public class PlanStatsUpdater {
         return switch (period) {
             case WEEK -> now.minusWeeks(1);
             case MONTH -> now.minusMonths(1);
-            case ALL -> LocalDateTime.MIN;
+            case ALL -> LocalDateTime.of(2000, 1, 1, 0, 0);
         };
     }
 

--- a/src/main/java/com/bready/server/stats/service/PlanStatsUpdater.java
+++ b/src/main/java/com/bready/server/stats/service/PlanStatsUpdater.java
@@ -6,7 +6,6 @@ import com.bready.server.stats.repository.PlanStatsRepository;
 import com.bready.server.trigger.repository.SwitchLogRepository;
 import com.bready.server.trigger.repository.TriggerRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -23,6 +22,7 @@ public class PlanStatsUpdater {
     private final TriggerRepository triggerRepository;
     private final SwitchLogRepository switchLogRepository;
 
+    @Transactional
     public void recalculate(Long planId, StatsPeriod period) {
 
         LocalDateTime from = resolveFrom(period);
@@ -37,23 +37,14 @@ public class PlanStatsUpdater {
                 calculateReliability(triggerCount, switchCount);
 
         PlanStats stats = planStatsRepository
-                                .findByPlanIdAndPeriod(planId, period)
-                                .orElse(null);
-
-        if (stats == null) {
-            try {
-                stats = PlanStats.create(planId, period, (int) triggerCount, (int) switchCount, reliability);
-                planStatsRepository.save(stats);
-                return;
-            } catch (DataIntegrityViolationException e) {
-                stats = planStatsRepository
-                        .findByPlanIdAndPeriod(planId, period)
-                        .orElseThrow();
-            }
-        }
+                .findByPlanIdAndPeriodForUpdate(planId, period)
+                .orElseGet(() -> {
+                    PlanStats newStats =
+                            PlanStats.create(planId, period, 0, 0, BigDecimal.ZERO);
+                    return planStatsRepository.save(newStats);
+                });
 
         stats.update((int) triggerCount, (int) switchCount, reliability);
-        planStatsRepository.save(stats);
     }
 
     private LocalDateTime resolveFrom(StatsPeriod period) {
@@ -62,7 +53,7 @@ public class PlanStatsUpdater {
         return switch (period) {
             case WEEK -> now.minusWeeks(1);
             case MONTH -> now.minusMonths(1);
-            case ALL -> LocalDateTime.of(2000, 1, 1, 0, 0);
+            case ALL -> null;
         };
     }
 

--- a/src/main/java/com/bready/server/stats/service/PlanStatsUpdater.java
+++ b/src/main/java/com/bready/server/stats/service/PlanStatsUpdater.java
@@ -74,7 +74,7 @@ public class PlanStatsUpdater {
             return BigDecimal.valueOf(100);
         }
 
-        double ratio = 1 - ((double) switchCount / triggerCount);
+        double ratio = Math.max(0, 1 - ((double) switchCount / triggerCount));
 
         return BigDecimal.valueOf(ratio * 100)
                 .setScale(2, RoundingMode.HALF_UP);

--- a/src/main/java/com/bready/server/trigger/repository/SwitchLogRepository.java
+++ b/src/main/java/com/bready/server/trigger/repository/SwitchLogRepository.java
@@ -53,7 +53,7 @@ public interface SwitchLogRepository extends JpaRepository<SwitchLog, Long> {
         join sl.decision d
         join d.trigger t
         where t.plan.id = :planId
-          and sl.createdAt >= :from
+          and (:from is null or sl.createdAt >= :from)
     """)
     long countSwitchByPlanIdAndPeriod(@Param("planId") Long planId, @Param("from") LocalDateTime from);
 

--- a/src/main/java/com/bready/server/trigger/repository/SwitchLogRepository.java
+++ b/src/main/java/com/bready/server/trigger/repository/SwitchLogRepository.java
@@ -47,5 +47,15 @@ public interface SwitchLogRepository extends JpaRepository<SwitchLog, Long> {
     """)
     long countByOwnerIdAndPeriod(@Param("ownerId")Long ownerId, @Param("startAt")LocalDateTime startAt);
 
+    @Query("""
+        select count(sl)
+        from SwitchLog sl
+        join sl.decision d
+        join d.trigger t
+        where t.plan.id = :planId
+          and sl.createdAt >= :from
+    """)
+    long countSwitchByPlanIdAndPeriod(@Param("planId") Long planId, @Param("from") LocalDateTime from);
+
     boolean existsByDecision_Id(Long decisionId);
 }

--- a/src/main/java/com/bready/server/trigger/repository/TriggerRepository.java
+++ b/src/main/java/com/bready/server/trigger/repository/TriggerRepository.java
@@ -39,7 +39,7 @@ public interface TriggerRepository extends JpaRepository<Trigger, Long> {
     select count(t)
     from Trigger t
     where t.plan.id = :planId
-      and t.occurredAt >= :from
+      and (:from is null or t.occurredAt >= :from)
     """)
     long countByPlanIdAndPeriod(@Param("planId") Long planId, @Param("from") LocalDateTime from);
 }

--- a/src/main/java/com/bready/server/trigger/repository/TriggerRepository.java
+++ b/src/main/java/com/bready/server/trigger/repository/TriggerRepository.java
@@ -34,4 +34,12 @@ public interface TriggerRepository extends JpaRepository<Trigger, Long> {
         group by t.triggerType
     """)
     List<TriggerTypeCount> countByTriggerType(@Param("ownerId") Long ownerId, @Param("startAt") LocalDateTime startAt);
+
+    @Query("""
+    select count(t)
+    from Trigger t
+    where t.plan.id = :planId
+      and t.occurredAt >= :from
+    """)
+    long countByPlanIdAndPeriod(@Param("planId") Long planId, @Param("from") LocalDateTime from);
 }

--- a/src/main/java/com/bready/server/trigger/service/SwitchService.java
+++ b/src/main/java/com/bready/server/trigger/service/SwitchService.java
@@ -6,7 +6,7 @@ import com.bready.server.place.repository.PlaceCandidateRepository;
 import com.bready.server.plan.domain.CategoryState;
 import com.bready.server.plan.domain.PlanCategory;
 import com.bready.server.plan.repository.CategoryStateRepository;
-import com.bready.server.stats.service.PlanStatsService;
+import com.bready.server.stats.event.SwitchLogCreatedEvent;
 import com.bready.server.trigger.domain.Decision;
 import com.bready.server.trigger.domain.SwitchLog;
 import com.bready.server.trigger.dto.DecisionSwitchRequest;
@@ -15,6 +15,7 @@ import com.bready.server.trigger.exception.TriggerSwitchErrorCase;
 import com.bready.server.trigger.repository.DecisionRepository;
 import com.bready.server.trigger.repository.SwitchLogRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -27,7 +28,7 @@ public class SwitchService {
     private final SwitchLogRepository switchLogRepository;
     private final CategoryStateRepository categoryStateRepository;
     private final PlaceCandidateRepository placeCandidateRepository;
-    private final PlanStatsService planStatsService;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Transactional
     public DecisionSwitchResponse executeSwitch(Long decisionId, DecisionSwitchRequest request) {
@@ -104,7 +105,7 @@ public class SwitchService {
             throw ApplicationException.from(TriggerSwitchErrorCase.ALREADY_SWITCHED);
         }
 
-        planStatsService.increaseSwitchCount(planId);
+        eventPublisher.publishEvent(new SwitchLogCreatedEvent(planId));
 
         return DecisionSwitchResponse.builder()
                 .switchLogId(saved.getId())

--- a/src/main/java/com/bready/server/trigger/service/TriggerService.java
+++ b/src/main/java/com/bready/server/trigger/service/TriggerService.java
@@ -5,7 +5,7 @@ import com.bready.server.plan.domain.CategoryState;
 import com.bready.server.plan.domain.PlanCategory;
 import com.bready.server.plan.repository.CategoryStateRepository;
 import com.bready.server.plan.repository.PlanCategoryRepository;
-import com.bready.server.plan.repository.PlanRepository;
+import com.bready.server.stats.event.TriggerCreatedEvent;
 import com.bready.server.stats.service.PlanStatsService;
 import com.bready.server.trigger.domain.Trigger;
 import com.bready.server.trigger.dto.TriggerCreateRequest;
@@ -13,6 +13,7 @@ import com.bready.server.trigger.dto.TriggerCreateResponse;
 import com.bready.server.trigger.exception.TriggerErrorCase;
 import com.bready.server.trigger.repository.TriggerRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -20,11 +21,11 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class TriggerService {
 
-    private final PlanRepository planRepository;
     private final PlanCategoryRepository planCategoryRepository;
     private final TriggerRepository triggerRepository;
     private final PlanStatsService planStatsService;
     private final CategoryStateRepository categoryStateRepository;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Transactional
     public TriggerCreateResponse createTrigger(TriggerCreateRequest request) {
@@ -52,14 +53,10 @@ public class TriggerService {
                 )
         );
 
-        // TODO: 인증 도입 후 플랜 소유자 검증 로직 추가 필요
-        // if (!category.getPlan().isOwnedBy(currentUserId)) {
-        //     throw ApplicationException.from(TriggerErrorCase.NO_TRIGGER_PERMISSION);
-        // }
+        Long planId = category.getPlan().getId();
 
-
-        // 통계 증가 (결정/장소 변경 없음)
-        planStatsService.increaseTriggerCount(category.getPlan().getId());
+        // 이벤트 발행
+        eventPublisher.publishEvent(new TriggerCreatedEvent(planId));
 
         return TriggerCreateResponse.builder()
                 .triggerId(trigger.getId())

--- a/src/main/java/com/bready/server/trigger/service/TriggerService.java
+++ b/src/main/java/com/bready/server/trigger/service/TriggerService.java
@@ -16,6 +16,8 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+
 @Service
 @RequiredArgsConstructor
 public class TriggerService {
@@ -52,9 +54,10 @@ public class TriggerService {
         );
 
         Long planId = category.getPlan().getId();
+        LocalDateTime occurredAt = trigger.getOccurredAt();
 
         // 이벤트 발행
-        eventPublisher.publishEvent(new TriggerCreatedEvent(planId));
+        eventPublisher.publishEvent(new TriggerCreatedEvent(planId,occurredAt));
 
         return TriggerCreateResponse.builder()
                 .triggerId(trigger.getId())

--- a/src/main/java/com/bready/server/trigger/service/TriggerService.java
+++ b/src/main/java/com/bready/server/trigger/service/TriggerService.java
@@ -6,7 +6,6 @@ import com.bready.server.plan.domain.PlanCategory;
 import com.bready.server.plan.repository.CategoryStateRepository;
 import com.bready.server.plan.repository.PlanCategoryRepository;
 import com.bready.server.stats.event.TriggerCreatedEvent;
-import com.bready.server.stats.service.PlanStatsService;
 import com.bready.server.trigger.domain.Trigger;
 import com.bready.server.trigger.dto.TriggerCreateRequest;
 import com.bready.server.trigger.dto.TriggerCreateResponse;
@@ -23,7 +22,6 @@ public class TriggerService {
 
     private final PlanCategoryRepository planCategoryRepository;
     private final TriggerRepository triggerRepository;
-    private final PlanStatsService planStatsService;
     private final CategoryStateRepository categoryStateRepository;
     private final ApplicationEventPublisher eventPublisher;
 

--- a/src/test/java/com/bready/server/trigger/service/SwitchServiceTest.java
+++ b/src/test/java/com/bready/server/trigger/service/SwitchServiceTest.java
@@ -7,6 +7,7 @@ import com.bready.server.plan.domain.CategoryState;
 import com.bready.server.plan.domain.Plan;
 import com.bready.server.plan.domain.PlanCategory;
 import com.bready.server.plan.repository.CategoryStateRepository;
+import com.bready.server.stats.event.SwitchLogCreatedEvent;
 import com.bready.server.stats.service.PlanStatsService;
 import com.bready.server.trigger.domain.Decision;
 import com.bready.server.trigger.domain.SwitchLog;
@@ -21,6 +22,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 
 import java.time.LocalDateTime;
 import java.util.Optional;
@@ -48,6 +50,8 @@ class SwitchServiceTest {
     private PlaceCandidateRepository placeCandidateRepository;
     @Mock
     private PlanStatsService planStatsService;
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
 
     @Test
     @DisplayName("SWITCH 결정 전환 성공")
@@ -106,7 +110,7 @@ class SwitchServiceTest {
 
         assertThat(response.fromCandidateId()).isEqualTo(fromCandidateId);
         assertThat(response.toCandidateId()).isEqualTo(toCandidateId);
-        verify(planStatsService).increaseSwitchCount(planId);
+        verify(eventPublisher).publishEvent(any(SwitchLogCreatedEvent.class));
     }
 
     @Test

--- a/src/test/java/com/bready/server/trigger/service/TriggerServiceTest.java
+++ b/src/test/java/com/bready/server/trigger/service/TriggerServiceTest.java
@@ -6,6 +6,7 @@ import com.bready.server.plan.domain.Plan;
 import com.bready.server.plan.domain.PlanCategory;
 import com.bready.server.plan.repository.CategoryStateRepository;
 import com.bready.server.plan.repository.PlanCategoryRepository;
+import com.bready.server.stats.event.TriggerCreatedEvent;
 import com.bready.server.stats.service.PlanStatsService;
 import com.bready.server.trigger.domain.Trigger;
 import com.bready.server.trigger.domain.TriggerType;
@@ -19,6 +20,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 
 import java.time.LocalDateTime;
 import java.util.Optional;
@@ -40,6 +42,7 @@ class TriggerServiceTest {
     @Mock private TriggerRepository triggerRepository;
     @Mock private PlanStatsService planStatsService;
     @Mock private CategoryStateRepository categoryStateRepository;
+    @Mock private ApplicationEventPublisher eventPublisher;
 
     @Test
     @DisplayName("트리거 생성 성공")
@@ -75,7 +78,7 @@ class TriggerServiceTest {
                 triggerService.createTrigger(new TriggerCreateRequest(planId, categoryId, TriggerType.WEATHER_BAD));
 
         assertThat(response.triggerId()).isEqualTo(100L);
-        verify(planStatsService).increaseTriggerCount(planId);
+        verify(eventPublisher).publishEvent(any(TriggerCreatedEvent.class));
     }
 
     @Test


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #56 

## 📝 작업 내용
### 기존 성능 (JOIN 기반)
**k6 부하 테스트 결과**
```
p95 = 2.04s
avg = 913ms
```
**JOIN API 실행 시간:**
```
1290ms
1996ms
1843ms
533ms
511ms
```
=> 부하 상황에서 500ms ~ 2초까지 변동

### 해결 전략 : Materialized View 패턴 도입
**실시간 집계를 제거하고, 사전 계산된 통계 테이블(plan_stats) 을 조회하도록 구조 변경.**
### 설계 방식
```
1. 통계 테이블 생성
2. 이벤트 기반 통계 갱신 구조
3. TransactionalEventListener 적용 (트랜잭션 커밋 이후에만 통계 갱신)
4. Async 처리

```
## 🖼️ 스크린샷 (선택)
### 성능 개선 결과

**JOIN (1843ms ~ 1996ms)**
```
2026-02-13T01:44:29.717+09:00  INFO 11752 --- [nio-8080-exec-7] c.b.server.global.aop.LoggingAspect      : [START] com.bready.server.stats.service.PlanStatsJoinService.getStats() args = [1, WEEK, 10]
2026-02-13T01:44:29.718+09:00  INFO 11752 --- [io-8080-exec-76] c.b.s.global.aop.ExecutionTimeAspect     : [API 실행 시간] 1996ms - com.bready.server.stats.controller.PlanStatsController.getJoinStats
2026-02-13T01:44:29.731+09:00  INFO 11752 --- [io-8080-exec-43] c.b.s.global.aop.ExecutionTimeAspect     : [API 실행 시간] 1843ms - com.bready.server.stats.controller.PlanStatsController.getJoinStats

```

**Materialized (19ms ~ 21ms)**
```
2026-02-13T01:44:58.122+09:00  INFO 11752 --- [io-8080-exec-90] c.b.server.global.aop.LoggingAspect      : [START] com.bready.server.stats.service.PlanStatsMaterializedService.getStats() args = [1, WEEK, 10]
2026-02-13T01:44:58.123+09:00  INFO 11752 --- [io-8080-exec-76] c.b.server.global.aop.LoggingAspect      : [START] com.bready.server.stats.service.PlanStatsMaterializedService.getStats() args = [1, WEEK, 10]
2026-02-13T01:44:58.123+09:00  INFO 11752 --- [o-8080-exec-104] c.b.server.global.aop.LoggingAspect      : [START] com.bready.server.stats.service.PlanStatsMaterializedService.getStats() args = [1, WEEK, 10]
2026-02-13T01:44:58.133+09:00  INFO 11752 --- [io-8080-exec-90] c.b.server.global.aop.LoggingAspect      : [ END ] com.bready.server.stats.service.PlanStatsMaterializedService.getStats()
2026-02-13T01:44:58.136+09:00  INFO 11752 --- [o-8080-exec-104] c.b.server.global.aop.LoggingAspect      : [ END ] com.bready.server.stats.service.PlanStatsMaterializedService.getStats()
2026-02-13T01:44:58.136+09:00  INFO 11752 --- [io-8080-exec-76] c.b.server.global.aop.LoggingAspect      : [ END ] com.bready.server.stats.service.PlanStatsMaterializedService.getStats()
2026-02-13T01:44:58.137+09:00  INFO 11752 --- [io-8080-exec-90] c.b.s.global.aop.ExecutionTimeAspect     : [API 실행 시간] 19ms - com.bready.server.stats.controller.PlanStatsController.getMaterializedStats
2026-02-13T01:44:58.140+09:00  INFO 11752 --- [io-8080-exec-76] c.b.s.global.aop.ExecutionTimeAspect     : [API 실행 시간] 21ms - com.bready.server.stats.controller.PlanStatsController.getMaterializedStats
2026-02-13T01:44:58.140+09:00  INFO 11752 --- [o-8080-exec-104] c.b.s.global.aop.ExecutionTimeAspect     : [API 실행 시간] 21ms - com.bready.server.stats.controller.PlanStatsController.getMaterializedStats
```
**=> 최대 약 100배의 성능 개선 완료**

## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특히 봐주었으면 하는 부분이 있다면 작성해주세요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 애플리케이션 수준 비동기 실행 활성화
  * 트리거·스위치 생성 시 이벤트 발행 및 비동기 리스너로 통계 재계산 처리
  * 플랜별 통계 집계·재계산 서비스 추가 및 페이징 조회 개선
  * 통계 응답용 빈 결과 생성 유틸 제공

* **리팩터**
  * 통계 업데이트를 직접 호출하던 흐름에서 이벤트 기반 비동기 처리로 전환

* **테스트**
  * 이벤트 발행 동작을 검증하도록 단위 테스트 업데이트
<!-- end of auto-generated comment: release notes by coderabbit.ai -->