### PR TITLE
[feat] 네이버 소셜 로그인, 로그아웃 API 구현 

### DIFF
--- a/src/main/java/com/bready/server/auth/client/NaverOAuthClient.java
+++ b/src/main/java/com/bready/server/auth/client/NaverOAuthClient.java
@@ -1,0 +1,45 @@
+package com.bready.server.auth.client;
+
+import com.bready.server.auth.config.NaverOAuthProperties;
+import com.bready.server.auth.dto.NaverTokenResponse;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.reactive.function.BodyInserters;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Component
+public class NaverOAuthClient {
+
+    private static final String TOKEN_URI = "https://nid.naver.com/oauth2.0/token";
+    private final NaverOAuthProperties properties;
+    private final WebClient webClient;
+
+    public NaverOAuthClient(
+            NaverOAuthProperties properties,
+            @Qualifier("naverWebClient") WebClient webClient
+    ) {
+        this.properties = properties;
+        this.webClient = webClient;
+    }
+
+    public NaverTokenResponse getToken(String authorizationCode, String state) {
+        MultiValueMap<String, String> formData = new LinkedMultiValueMap<>();
+        formData.add("grant_type", "authorization_code");
+        formData.add("client_id", properties.getClientId());
+        formData.add("client_secret", properties.getClientSecret());
+        formData.add("redirect_uri", properties.getRedirectUri());
+        formData.add("code", authorizationCode);
+        formData.add("state", state);
+
+        return webClient.post()
+                .uri(TOKEN_URI)
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                .body(BodyInserters.fromFormData(formData))
+                .retrieve()
+                .bodyToMono(NaverTokenResponse.class)
+                .block();
+    }
+}

--- a/src/main/java/com/bready/server/auth/client/NaverOAuthClient.java
+++ b/src/main/java/com/bready/server/auth/client/NaverOAuthClient.java
@@ -40,6 +40,6 @@ public class NaverOAuthClient {
                 .body(BodyInserters.fromFormData(formData))
                 .retrieve()
                 .bodyToMono(NaverTokenResponse.class)
-                .block();
+                .block(java.time.Duration.ofSeconds(5));
     }
 }

--- a/src/main/java/com/bready/server/auth/client/NaverUserInfoClient.java
+++ b/src/main/java/com/bready/server/auth/client/NaverUserInfoClient.java
@@ -23,6 +23,6 @@ public class NaverUserInfoClient {
                 .header(HttpHeaders.AUTHORIZATION, "Bearer " + naverAccessToken)
                 .retrieve()
                 .bodyToMono(NaverUserInfoResponse.class)
-                .block();
+                .block(java.time.Duration.ofSeconds(5));
     }
 }

--- a/src/main/java/com/bready/server/auth/client/NaverUserInfoClient.java
+++ b/src/main/java/com/bready/server/auth/client/NaverUserInfoClient.java
@@ -1,0 +1,28 @@
+package com.bready.server.auth.client;
+
+import com.bready.server.auth.dto.NaverUserInfoResponse;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Component
+public class NaverUserInfoClient {
+
+    private static final String USER_INFO_URI = "https://openapi.naver.com/v1/nid/me";
+
+    private final WebClient webClient;
+
+    public NaverUserInfoClient(@Qualifier("naverWebClient") WebClient webClient) {
+        this.webClient = webClient;
+    }
+
+    public NaverUserInfoResponse getUserInfo(String naverAccessToken) {
+        return webClient.get()
+                .uri(USER_INFO_URI)
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + naverAccessToken)
+                .retrieve()
+                .bodyToMono(NaverUserInfoResponse.class)
+                .block();
+    }
+}

--- a/src/main/java/com/bready/server/auth/config/NaverOAuthProperties.java
+++ b/src/main/java/com/bready/server/auth/config/NaverOAuthProperties.java
@@ -1,0 +1,16 @@
+package com.bready.server.auth.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "oauth.naver")
+public class NaverOAuthProperties {
+    private String clientId;
+    private String clientSecret;
+    private String redirectUri;
+}

--- a/src/main/java/com/bready/server/auth/controller/AuthController.java
+++ b/src/main/java/com/bready/server/auth/controller/AuthController.java
@@ -3,6 +3,7 @@ package com.bready.server.auth.controller;
 import com.bready.server.auth.dto.*;
 import com.bready.server.auth.service.AuthService;
 import com.bready.server.auth.service.KakaoAuthService;
+import com.bready.server.auth.service.NaverAuthService;
 import com.bready.server.global.response.CommonResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -21,6 +22,7 @@ public class AuthController {
 
     private final AuthService authService;
     private final KakaoAuthService kakaoAuthService;
+    private final NaverAuthService naverAuthService;
 
 
     @PostMapping("/signup")
@@ -105,5 +107,27 @@ public class AuthController {
             @Valid @RequestBody KakaoLoginRequest request
     ) {
         return CommonResponse.success(kakaoAuthService.login(request));
+    }
+
+    @PostMapping("/naver/login")
+    @ResponseStatus(HttpStatus.OK)
+    @Operation(
+            summary = "네이버 로그인",
+            description = "인가 코드와 state로 네이버 인증 후 access, refresh 토큰 발급 및 사용자 정보 반환"
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "네이버 로그인 성공",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "400", description = "이메일 제공 동의 필수",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "401", description = "유효하지 않은 네이버 인증 정보",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "502", description = "네이버 인증 서버 통신 실패",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class)))
+    })
+    public CommonResponse<NaverLoginResponse> naverLogin(
+            @Valid @RequestBody NaverLoginRequest request
+    ) {
+        return CommonResponse.success(naverAuthService.login(request.getCode(), request.getState()));
     }
 }

--- a/src/main/java/com/bready/server/auth/controller/AuthController.java
+++ b/src/main/java/com/bready/server/auth/controller/AuthController.java
@@ -87,6 +87,27 @@ public class AuthController {
         return CommonResponse.success(authService.refresh(request));
     }
 
+    @PostMapping("/logout")
+    @ResponseStatus(HttpStatus.OK)
+    @Operation(
+            summary = "로그아웃",
+            description = "RefreshToken을 무효화하여 로그아웃 처리"
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "로그아웃 성공",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "400", description = "필수 입력값 누락",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "401", description = "유효하지 않은 토큰 또는 만료된 토큰",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class)))
+    })
+    public CommonResponse<Void> logout(
+            @Valid @RequestBody RefreshRequest request
+    ) {
+        authService.logout(request);
+        return CommonResponse.success(null);
+    }
+
     @PostMapping("/kakao/login")
     @ResponseStatus(HttpStatus.OK)
     @Operation(

--- a/src/main/java/com/bready/server/auth/controller/AuthController.java
+++ b/src/main/java/com/bready/server/auth/controller/AuthController.java
@@ -109,11 +109,29 @@ public class AuthController {
         return CommonResponse.success(kakaoAuthService.login(request));
     }
 
+    // 네이버 자동 콜백 처리 (네이버에서 직접 호출)
+    @GetMapping("/naver/callback")
+    @ResponseStatus(HttpStatus.OK)
+    @Operation(
+            summary = "네이버 로그인 콜백",
+            description = "네이버에서 redirect되는 code/state를 받아 로그인 처리"
+    )
+    public CommonResponse<NaverLoginResponse> naverCallback(
+            @RequestParam String code,
+            @RequestParam String state
+    ) {
+        return CommonResponse.success(
+                naverAuthService.login(code, state)
+        );
+    }
+
+
+    // Swagger 테스트용 (수동 테스트)
     @PostMapping("/naver/login")
     @ResponseStatus(HttpStatus.OK)
     @Operation(
-            summary = "네이버 로그인",
-            description = "인가 코드와 state로 네이버 인증 후 access, refresh 토큰 발급 및 사용자 정보 반환"
+            summary = "네이버 로그인 (Swagger 테스트용)",
+            description = "인가 코드와 state를 직접 입력하여 로그인 테스트"
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "네이버 로그인 성공",
@@ -128,6 +146,8 @@ public class AuthController {
     public CommonResponse<NaverLoginResponse> naverLogin(
             @Valid @RequestBody NaverLoginRequest request
     ) {
-        return CommonResponse.success(naverAuthService.login(request.getCode(), request.getState()));
+        return CommonResponse.success(
+                naverAuthService.login(request.getCode(), request.getState())
+        );
     }
 }

--- a/src/main/java/com/bready/server/auth/dto/NaverLoginRequest.java
+++ b/src/main/java/com/bready/server/auth/dto/NaverLoginRequest.java
@@ -1,0 +1,16 @@
+package com.bready.server.auth.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class NaverLoginRequest {
+
+    @NotBlank(message = "인가 코드는 필수입니다.")
+    private String code;
+
+    @NotBlank(message = "state 값은 필수입니다.")
+    private String state;
+}

--- a/src/main/java/com/bready/server/auth/dto/NaverLoginResponse.java
+++ b/src/main/java/com/bready/server/auth/dto/NaverLoginResponse.java
@@ -1,5 +1,6 @@
 package com.bready.server.auth.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -9,7 +10,8 @@ public class NaverLoginResponse {
 
     private String accessToken;
     private String refreshToken;
-    private boolean isNewUser;
+    @JsonProperty("isNewUser")
+    private boolean newUser;
     private UserDto user;
 
     @Getter

--- a/src/main/java/com/bready/server/auth/dto/NaverLoginResponse.java
+++ b/src/main/java/com/bready/server/auth/dto/NaverLoginResponse.java
@@ -1,0 +1,23 @@
+package com.bready.server.auth.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class NaverLoginResponse {
+
+    private String accessToken;
+    private String refreshToken;
+    private boolean isNewUser;
+    private UserDto user;
+
+    @Getter
+    @Builder
+    public static class UserDto {
+        private Long userId;
+        private String nickname;
+        private String email;
+        private String joinedAt;
+    }
+}

--- a/src/main/java/com/bready/server/auth/dto/NaverTokenResponse.java
+++ b/src/main/java/com/bready/server/auth/dto/NaverTokenResponse.java
@@ -1,0 +1,28 @@
+package com.bready.server.auth.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class NaverTokenResponse {
+
+    @JsonProperty("access_token")
+    private String accessToken;
+
+    @JsonProperty("refresh_token")
+    private String refreshToken;
+
+    @JsonProperty("token_type")
+    private String tokenType;
+
+    @JsonProperty("expires_in")
+    private String expiresIn;
+
+    @JsonProperty("error")
+    private String error;
+
+    @JsonProperty("error_description")
+    private String errorDescription;
+}

--- a/src/main/java/com/bready/server/auth/dto/NaverUserInfoResponse.java
+++ b/src/main/java/com/bready/server/auth/dto/NaverUserInfoResponse.java
@@ -1,0 +1,23 @@
+package com.bready.server.auth.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class NaverUserInfoResponse {
+
+    private String resultcode;
+    private String message;
+    private Response response;
+
+    @Getter
+    @NoArgsConstructor
+    public static class Response {
+        private String id;
+        private String email;
+        private String nickname;
+        private String name;
+        private String profile_image;
+    }
+}

--- a/src/main/java/com/bready/server/auth/dto/NaverUserInfoResponse.java
+++ b/src/main/java/com/bready/server/auth/dto/NaverUserInfoResponse.java
@@ -1,5 +1,6 @@
 package com.bready.server.auth.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -18,6 +19,7 @@ public class NaverUserInfoResponse {
         private String email;
         private String nickname;
         private String name;
-        private String profile_image;
+        @JsonProperty("profile_image")
+        private String profileImage;
     }
 }

--- a/src/main/java/com/bready/server/auth/exception/AuthErrorCase.java
+++ b/src/main/java/com/bready/server/auth/exception/AuthErrorCase.java
@@ -24,7 +24,11 @@ public enum AuthErrorCase implements ErrorCase {
 
     // 카카오 소셜 로그인
     INVALID_KAKAO_AUTH(HttpStatus.UNAUTHORIZED, 4013,"유효하지 않은 카카오 인증 정보입니다."),
-    KAKAO_API_COMMUNICATION_FAILED(HttpStatus.BAD_GATEWAY, 5021, "카카오 인증 서버와 통신에 실패했습니다.");
+    KAKAO_API_COMMUNICATION_FAILED(HttpStatus.BAD_GATEWAY, 5021, "카카오 인증 서버와 통신에 실패했습니다."),
+
+    // 네이버 소셜 로그인
+    INVALID_NAVER_AUTH(HttpStatus.UNAUTHORIZED, 4014, "유효하지 않은 네이버 인증 정보입니다."),
+    NAVER_API_COMMUNICATION_FAILED(HttpStatus.BAD_GATEWAY, 5022, "네이버 인증 서버와 통신에 실패했습니다.");
 
     private final HttpStatus httpStatus;
     private final Integer errorCode;

--- a/src/main/java/com/bready/server/auth/service/AuthService.java
+++ b/src/main/java/com/bready/server/auth/service/AuthService.java
@@ -105,4 +105,23 @@ public class AuthService {
 
         return tokenIssuer.issue(userId);
     }
+
+
+    @Transactional
+    public void logout(RefreshRequest request) {
+        jwtTokenProvider.validateRefreshToken(request.getRefreshToken());
+
+        Long userId = jwtTokenProvider.getUserId(request.getRefreshToken());
+
+        // Redis 저장된 토큰 조회
+        RefreshToken saved = refreshTokenRepository.findById(String.valueOf(userId))
+                .orElseThrow(() -> new ApplicationException(AuthErrorCase.REFRESH_TOKEN_INVALID));
+
+        if (!saved.getToken().equals(request.getRefreshToken())) {
+            throw new ApplicationException(AuthErrorCase.REFRESH_TOKEN_INVALID);
+        }
+
+        // Redis에서 삭제
+        refreshTokenRepository.deleteById(String.valueOf(userId));
+    }
 }

--- a/src/main/java/com/bready/server/auth/service/NaverAuthService.java
+++ b/src/main/java/com/bready/server/auth/service/NaverAuthService.java
@@ -48,7 +48,11 @@ public class NaverAuthService {
         try {
             NaverTokenResponse token = naverOAuthClient.getToken(code, state);
 
-            if (token != null && token.getError() != null) {
+            if (token == null) {
+                throw new ApplicationException(AuthErrorCase.NAVER_API_COMMUNICATION_FAILED);
+            }
+
+            if (token.getError() != null) {
                 throw new ApplicationException(AuthErrorCase.INVALID_NAVER_AUTH);
             }
 

--- a/src/main/java/com/bready/server/auth/service/NaverAuthService.java
+++ b/src/main/java/com/bready/server/auth/service/NaverAuthService.java
@@ -1,0 +1,80 @@
+package com.bready.server.auth.service;
+
+import com.bready.server.auth.client.NaverOAuthClient;
+import com.bready.server.auth.client.NaverUserInfoClient;
+import com.bready.server.auth.dto.NaverLoginResponse;
+import com.bready.server.auth.dto.NaverTokenResponse;
+import com.bready.server.auth.dto.NaverUserInfoResponse;
+import com.bready.server.auth.exception.AuthErrorCase;
+import com.bready.server.global.exception.ApplicationException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+
+@Service
+@RequiredArgsConstructor
+public class NaverAuthService {
+
+    private final NaverOAuthClient naverOAuthClient;
+    private final NaverUserInfoClient naverUserInfoClient;
+    private final NaverAuthTransactionHandler naverAuthTransactionHandler;
+
+    public NaverLoginResponse login(String code, String state) {
+
+        if (code == null || code.isBlank()) {
+            throw new ApplicationException(AuthErrorCase.INVALID_NAVER_AUTH);
+        }
+        if (state == null || state.isBlank()) {
+            throw new ApplicationException(AuthErrorCase.INVALID_NAVER_AUTH);
+        }
+
+        NaverTokenResponse token = exchangeNaverToken(code, state);
+        String naverAccessToken = token.getAccessToken();
+
+        if (naverAccessToken == null || naverAccessToken.isBlank()) {
+            throw new ApplicationException(AuthErrorCase.INVALID_NAVER_AUTH);
+        }
+
+        NaverUserInfoResponse userInfo = fetchNaverUserInfo(naverAccessToken);
+
+        if (userInfo == null || userInfo.getResponse() == null || userInfo.getResponse().getId() == null) {
+            throw new ApplicationException(AuthErrorCase.INVALID_NAVER_AUTH);
+        }
+
+        return naverAuthTransactionHandler.processNaverLogin(userInfo);
+    }
+
+    private NaverTokenResponse exchangeNaverToken(String code, String state) {
+        try {
+            NaverTokenResponse token = naverOAuthClient.getToken(code, state);
+
+            if (token != null && token.getError() != null) {
+                throw new ApplicationException(AuthErrorCase.INVALID_NAVER_AUTH);
+            }
+
+            return token;
+        } catch (WebClientResponseException e) {
+            if (e.getStatusCode().is4xxClientError()) {
+                throw new ApplicationException(AuthErrorCase.INVALID_NAVER_AUTH);
+            }
+            throw new ApplicationException(AuthErrorCase.NAVER_API_COMMUNICATION_FAILED);
+        } catch (ApplicationException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new ApplicationException(AuthErrorCase.NAVER_API_COMMUNICATION_FAILED);
+        }
+    }
+
+    private NaverUserInfoResponse fetchNaverUserInfo(String naverAccessToken) {
+        try {
+            return naverUserInfoClient.getUserInfo(naverAccessToken);
+        } catch (WebClientResponseException e) {
+            if (e.getStatusCode().is4xxClientError()) {
+                throw new ApplicationException(AuthErrorCase.INVALID_NAVER_AUTH);
+            }
+            throw new ApplicationException(AuthErrorCase.NAVER_API_COMMUNICATION_FAILED);
+        } catch (Exception e) {
+            throw new ApplicationException(AuthErrorCase.NAVER_API_COMMUNICATION_FAILED);
+        }
+    }
+}

--- a/src/main/java/com/bready/server/auth/service/NaverAuthTransactionHandler.java
+++ b/src/main/java/com/bready/server/auth/service/NaverAuthTransactionHandler.java
@@ -1,0 +1,109 @@
+package com.bready.server.auth.service;
+
+import com.bready.server.auth.dto.NaverLoginResponse;
+import com.bready.server.auth.dto.NaverUserInfoResponse;
+import com.bready.server.auth.dto.TokenResponse;
+import com.bready.server.auth.exception.AuthErrorCase;
+import com.bready.server.global.exception.ApplicationException;
+import com.bready.server.user.domain.User;
+import com.bready.server.user.domain.UserAuthProvider;
+import com.bready.server.user.domain.UserProfile;
+import com.bready.server.user.exception.UserErrorCase;
+import com.bready.server.user.repository.UserProfileRepository;
+import com.bready.server.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class NaverAuthTransactionHandler {
+
+    private final UserRepository userRepository;
+    private final UserProfileRepository userProfileRepository;
+    private final TokenIssuer tokenIssuer;
+
+    @Transactional
+    public NaverLoginResponse processNaverLogin(NaverUserInfoResponse userInfo) {
+
+        String providerUserId = userInfo.getResponse().getId();
+
+        User user = userRepository
+                .findByAuthProviderAndProviderUserId(UserAuthProvider.NAVER, providerUserId)
+                .orElse(null);
+
+        boolean isNewUser = false;
+
+        if (user == null) {
+            String email = userInfo.getResponse().getEmail();
+            if (email == null || email.isBlank()) {
+                throw new ApplicationException(UserErrorCase.NAVER_EMAIL_CONSENT_REQUIRED);
+            }
+
+            if (userRepository.existsByEmail(email)) {
+                throw new ApplicationException(UserErrorCase.DUPLICATED_EMAIL);
+            }
+
+            String nickname = userInfo.getResponse().getNickname();
+            if (nickname == null || nickname.isBlank()) {
+                nickname = userInfo.getResponse().getName();
+            }
+            if (nickname == null || nickname.isBlank()) {
+                nickname = generateRandomNickname();
+            }
+
+            isNewUser = true;
+
+            try {
+                user = userRepository.save(
+                        User.createSocial(UserAuthProvider.NAVER, providerUserId, email)
+                );
+                userProfileRepository.save(UserProfile.create(user, nickname));
+            } catch (DataIntegrityViolationException e) {
+                if (userRepository.existsByEmail(email)) {
+                    throw new ApplicationException(UserErrorCase.DUPLICATED_EMAIL);
+                }
+
+                isNewUser = false;
+
+                user = userRepository
+                        .findByAuthProviderAndProviderUserId(UserAuthProvider.NAVER, providerUserId)
+                        .orElseThrow(() -> e);
+            }
+        }
+
+        TokenResponse tokens = tokenIssuer.issue(user.getId());
+
+        User userWithProfile = userRepository.findByIdWithProfile(user.getId())
+                .orElseThrow(() -> new ApplicationException(AuthErrorCase.INVALID_NAVER_AUTH));
+
+        String joinedAt = userWithProfile.getCreatedAt() == null ? null
+                : userWithProfile.getCreatedAt().atOffset(ZoneOffset.UTC)
+                .format(DateTimeFormatter.ISO_OFFSET_DATE_TIME);
+
+        String nicknameForResponse = userWithProfile.getUserProfile() != null
+                ? userWithProfile.getUserProfile().getNickname()
+                : null;
+
+        return NaverLoginResponse.builder()
+                .accessToken(tokens.getAccessToken())
+                .refreshToken(tokens.getRefreshToken())
+                .isNewUser(isNewUser)
+                .user(NaverLoginResponse.UserDto.builder()
+                        .userId(user.getId())
+                        .nickname(nicknameForResponse)
+                        .email(user.getEmail())
+                        .joinedAt(joinedAt)
+                        .build())
+                .build();
+    }
+
+    private String generateRandomNickname() {
+        return "사용자" + UUID.randomUUID().toString().replace("-", "").substring(0, 8);
+    }
+}

--- a/src/main/java/com/bready/server/auth/service/NaverAuthTransactionHandler.java
+++ b/src/main/java/com/bready/server/auth/service/NaverAuthTransactionHandler.java
@@ -93,7 +93,7 @@ public class NaverAuthTransactionHandler {
         return NaverLoginResponse.builder()
                 .accessToken(tokens.getAccessToken())
                 .refreshToken(tokens.getRefreshToken())
-                .isNewUser(isNewUser)
+                .newUser(isNewUser)
                 .user(NaverLoginResponse.UserDto.builder()
                         .userId(user.getId())
                         .nickname(nicknameForResponse)

--- a/src/main/java/com/bready/server/global/config/WebClientConfig.java
+++ b/src/main/java/com/bready/server/global/config/WebClientConfig.java
@@ -31,4 +31,22 @@ public class WebClientConfig {
                 )
                 .build();
     }
+    
+    @Bean(name = "naverWebClient")
+    public WebClient naverWebClient() {
+        HttpClient httpClient = HttpClient.create()
+                .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 5_000)
+                .responseTimeout(Duration.ofSeconds(5))
+                .doOnConnected(conn ->
+                        conn.addHandlerLast(new ReadTimeoutHandler(5))
+                                .addHandlerLast(new WriteTimeoutHandler(5))
+                );
+
+        return WebClient.builder()
+                .clientConnector(new ReactorClientHttpConnector(httpClient))
+                .codecs(configurer ->
+                        configurer.defaultCodecs().maxInMemorySize(1024 * 1024)
+                )
+                .build();
+    }
 }

--- a/src/main/java/com/bready/server/global/config/WebClientConfig.java
+++ b/src/main/java/com/bready/server/global/config/WebClientConfig.java
@@ -31,7 +31,7 @@ public class WebClientConfig {
                 )
                 .build();
     }
-    
+
     @Bean(name = "naverWebClient")
     public WebClient naverWebClient() {
         HttpClient httpClient = HttpClient.create()

--- a/src/main/java/com/bready/server/user/domain/User.java
+++ b/src/main/java/com/bready/server/user/domain/User.java
@@ -34,7 +34,7 @@ public class User extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private UserStatus status;
 
-    @OneToOne(mappedBy = "user")
+    @OneToOne(mappedBy = "user", fetch = FetchType.LAZY)
     private UserProfile userProfile;
 
     public static User createLocal(String email, String encodedPassword) {
@@ -59,5 +59,9 @@ public class User extends BaseEntity {
         user.authProvider = provider;
         user.providerUserId = providerUserId;
         return user;
+    }
+
+    public void setUserProfile(UserProfile userProfile) {
+        this.userProfile = userProfile;
     }
 }

--- a/src/main/java/com/bready/server/user/domain/UserProfile.java
+++ b/src/main/java/com/bready/server/user/domain/UserProfile.java
@@ -26,6 +26,8 @@ public class UserProfile {
         UserProfile profile = new UserProfile();
         profile.user = user;
         profile.nickname = nickname;
+        // 양방향 연관관계 세팅 추가
+        user.setUserProfile(profile);
         return profile;
     }
 }

--- a/src/main/java/com/bready/server/user/exception/UserErrorCase.java
+++ b/src/main/java/com/bready/server/user/exception/UserErrorCase.java
@@ -22,7 +22,10 @@ public enum UserErrorCase implements ErrorCase {
     DUPLICATED_EMAIL(HttpStatus.CONFLICT, 4091, "이미 사용 중인 이메일입니다."),
 
     // 소셜 로그인
-    KAKAO_EMAIL_CONSENT_REQUIRED(HttpStatus.BAD_REQUEST, 4104, "이메일 제공에 동의해야 가입/로그인이 가능합니다.");
+    KAKAO_EMAIL_CONSENT_REQUIRED(HttpStatus.BAD_REQUEST, 4104, "이메일 제공에 동의해야 가입/로그인이 가능합니다."),
+
+    // 네이버 이메일 동의 필수
+    NAVER_EMAIL_CONSENT_REQUIRED(HttpStatus.BAD_REQUEST, 4105, "네이버 로그인 시 이메일 제공 동의가 필요합니다.");
 
     private final HttpStatus httpStatus;
     private final Integer errorCode;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #59 

## 📝 작업 내용

> 네이버 OAuth2 기반 소셜 로그인 기능과 RefreshToken을 무효화하는 방식의 로그아웃 API를 구현했습니다. 

## 🖼️ 스크린샷 (선택)
### 네이버 소셜 로그인 성공
<img width="497" height="276" alt="네이버소셜로그인" src="https://github.com/user-attachments/assets/0febafb1-3189-404f-8c6c-1ce0cefe583e" />

### 로그아웃 성공
<img width="1495" height="945" alt="로그아웃성공" src="https://github.com/user-attachments/assets/89d4787e-687c-44e8-8276-1c6f5bbebbb2" />


### 로그아웃 된 토큰 무효화 확인 
<img width="1483" height="947" alt="로그아웃한토큰무효화" src="https://github.com/user-attachments/assets/15855218-3821-4f5f-8374-ed9ef3014732" />


## 💬 리뷰 요구사항 (선택)

> 소셜로그인할때 유저의 닉네임을 받아오지 못하여 null이 나오는 문제가 있었는데, User 엔티티에 UserProfile 생성 시 양방향 연관관계를 명시적 세팅 추가하여 해결하였으니 User, UserProfile 엔티티쪽 변경 참고해주시면 좋을 것 같습니다! 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 네이버 OAuth 로그인 지원 추가 — 네이버 계정으로 로그인/신규 가입 가능
  * 네이버 로그인 콜백 및 로그인 엔드포인트 추가로 인증 흐름 지원
  * 로그아웃 기능 추가 — 리프레시 토큰 무효화 처리

* **버그 수정/개선**
  * 네이버 인증·유저 정보 연동 안정성 및 오류 응답 처리 개선
  * 소셜 가입 시 프로필 연동 및 닉네임 생성 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->