### PR TITLE
[feat] S3 이미지 업로드 기능 구현 

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -97,6 +97,13 @@ jobs:
             NAVER_CLIENT_ID=${{ secrets.NAVER_CLIENT_ID }}
             NAVER_CLIENT_SECRET=${{ secrets.NAVER_CLIENT_SECRET }}
             NAVER_REDIRECT_URI=${{ secrets.NAVER_REDIRECT_URI }}
+            
+            CLOUD_AWS_REGION=${{ secrets.AWS_REGION }}
+            CLOUD_AWS_S3_BUCKET=${{ secrets.AWS_S3_BUCKET }}
+            CLOUD_AWS_S3_PUBLIC_PREFIX=${{ secrets.AWS_S3_PREFIX }}
+            CLOUD_AWS_CREDENTIALS_ACCESS_KEY=${{ secrets.AWS_ACCESS_KEY }}
+            CLOUD_AWS_CREDENTIALS_SECRET_KEY=${{ secrets.AWS_SECRET_KEY }}
+  
             EOF
             
             chmod 600 .env

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,11 @@ jobs:
       SPRING_DATA_REDIS_HOST: 127.0.0.1
       SPRING_DATA_REDIS_PORT: 6379
       JWT_SECRET: ${{ secrets.JWT_SECRET }}
+      CLOUD_AWS_REGION: ${{ secrets.AWS_REGION }}
+      CLOUD_AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
+      CLOUD_AWS_S3_PUBLIC_PREFIX: ${{ secrets.AWS_S3_PREFIX }}
+      CLOUD_AWS_CREDENTIALS_ACCESS_KEY: ${{ secrets.AWS_ACCESS_KEY }}
+      CLOUD_AWS_CREDENTIALS_SECRET_KEY: ${{ secrets.AWS_SECRET_KEY }}
 
     steps:
       - name: Checkout source

--- a/build.gradle
+++ b/build.gradle
@@ -76,6 +76,9 @@ dependencies {
 
 	// Prometheus registry
 	runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
+
+	// aws
+	implementation 'software.amazon.awssdk:s3:2.39.2'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/bready/server/global/config/s3/S3Config.java
+++ b/src/main/java/com/bready/server/global/config/s3/S3Config.java
@@ -1,0 +1,36 @@
+package com.bready.server.global.config.s3;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+@Configuration
+public class S3Config {
+
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region}")
+    private String region;
+
+    @Bean
+    public S3Client s3Client() {
+
+        AwsBasicCredentials credentials =
+                AwsBasicCredentials.create(accessKey, secretKey);
+
+        return S3Client.builder()
+                .region(Region.of(region))
+                .credentialsProvider(
+                        StaticCredentialsProvider.create(credentials)
+                )
+                .build();
+    }
+}

--- a/src/main/java/com/bready/server/global/config/s3/S3Config.java
+++ b/src/main/java/com/bready/server/global/config/s3/S3Config.java
@@ -11,17 +11,12 @@ import software.amazon.awssdk.services.s3.S3Client;
 @Configuration
 public class S3Config {
 
-    @Value("${cloud.aws.credentials.access-key}")
-    private String accessKey;
-
-    @Value("${cloud.aws.credentials.secret-key}")
-    private String secretKey;
-
-    @Value("${cloud.aws.region}")
-    private String region;
-
     @Bean
-    public S3Client s3Client() {
+    public S3Client s3Client(
+            @Value("${cloud.aws.credentials.access-key}") String accessKey,
+            @Value("${cloud.aws.credentials.secret-key}") String secretKey,
+            @Value("${cloud.aws.region}") String region
+    ) {
 
         AwsBasicCredentials credentials =
                 AwsBasicCredentials.create(accessKey, secretKey);

--- a/src/main/java/com/bready/server/s3/controller/S3Controller.java
+++ b/src/main/java/com/bready/server/s3/controller/S3Controller.java
@@ -1,0 +1,57 @@
+package com.bready.server.s3.controller;
+
+import com.bready.server.global.response.CommonResponse;
+import com.bready.server.s3.dto.FileUploadResponse;
+import com.bready.server.s3.service.S3Uploader;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/files")
+@Tag(name = "S3 API", description = "S3 파일 업로드/관리 API")
+public class S3Controller {
+
+    private final S3Uploader s3Uploader;
+
+    @PostMapping(value = "/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @Operation(
+            summary = "파일 업로드 (S3)",
+            description = """
+                    multipart/form-data로 파일을 업로드합니다.
+                    - S3 key 규칙: {public-prefix}/{folder}/{uuid}.{ext}
+                    - 현재 테스트 폴더: test
+                    - 업로드 성공 시 공개 URL을 반환합니다.
+                    """
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "업로드 성공",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "400", description = "잘못된 파일(빈 파일/파일명 없음/확장자 없음 등)",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "500", description = "S3 업로드 실패",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class)))
+    })
+    public CommonResponse<FileUploadResponse> upload(
+            @Parameter(description = "업로드할 파일", required = true)
+            @RequestPart("file") MultipartFile file
+    ) {
+        // DB에는 fileKey 저장, 응답은 url까지 같이
+        String fileKey = s3Uploader.uploadAndReturnKey(file, "test");
+        String url = s3Uploader.buildUrl(fileKey);
+
+        return CommonResponse.success(new FileUploadResponse(fileKey, url));
+    }
+}

--- a/src/main/java/com/bready/server/s3/controller/S3Controller.java
+++ b/src/main/java/com/bready/server/s3/controller/S3Controller.java
@@ -26,6 +26,7 @@ public class S3Controller {
 
     private final S3Uploader s3Uploader;
 
+    // 테스트용 업로드 API (실제 서비스에서는 S3Uploader를 각 도메인 Service에서 호출하여 사용합니다.)
     @PostMapping(value = "/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @Operation(
             summary = "파일 업로드 (S3)",

--- a/src/main/java/com/bready/server/s3/dto/FileUploadResponse.java
+++ b/src/main/java/com/bready/server/s3/dto/FileUploadResponse.java
@@ -1,5 +1,10 @@
 package com.bready.server.s3.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 public record FileUploadResponse(
+        @Schema(description = "S3 객체 키 (prefix 포함)")
+        String fileKey,
+        @Schema(description = "브라우저에서 바로 접근 가능한 공개 URL")
         String url
 ) {}

--- a/src/main/java/com/bready/server/s3/dto/FileUploadResponse.java
+++ b/src/main/java/com/bready/server/s3/dto/FileUploadResponse.java
@@ -1,0 +1,5 @@
+package com.bready.server.s3.dto;
+
+public record FileUploadResponse(
+        String url
+) {}

--- a/src/main/java/com/bready/server/s3/exception/S3ErrorCase.java
+++ b/src/main/java/com/bready/server/s3/exception/S3ErrorCase.java
@@ -1,0 +1,29 @@
+package com.bready.server.s3.exception;
+
+import com.bready.server.global.exception.ErrorCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+public enum S3ErrorCase implements ErrorCase {
+
+    EMPTY_FILE(HttpStatus.BAD_REQUEST, 14001, "파일이 없습니다."),
+    FILENAME_NOT_FOUND(HttpStatus.BAD_REQUEST, 14002, "업로드한 파일에 파일명이 없습니다."),
+    EXTENSION_NOT_FOUND(HttpStatus.BAD_REQUEST, 14003, "확장자가 없는 파일은 업로드할 수 없습니다."),
+
+    FILE_UPLOAD_FAIL(HttpStatus.BAD_REQUEST, 14004, "S3 업로드에 실패하였습니다."),
+    FILE_DELETE_FAIL(HttpStatus.BAD_REQUEST, 14005, "S3 삭제에 실패하였습니다.");
+
+    private final HttpStatus httpStatus;
+    private final Integer errorCode;
+    private final String message;
+
+    @Override
+    public Integer getHttpStatusCode() { return httpStatus.value(); }
+
+    @Override
+    public Integer getErrorCode() { return errorCode; }
+
+    @Override
+    public String getMessage() { return message; }
+}

--- a/src/main/java/com/bready/server/s3/exception/S3ErrorCase.java
+++ b/src/main/java/com/bready/server/s3/exception/S3ErrorCase.java
@@ -11,8 +11,8 @@ public enum S3ErrorCase implements ErrorCase {
     FILENAME_NOT_FOUND(HttpStatus.BAD_REQUEST, 14002, "업로드한 파일에 파일명이 없습니다."),
     EXTENSION_NOT_FOUND(HttpStatus.BAD_REQUEST, 14003, "확장자가 없는 파일은 업로드할 수 없습니다."),
 
-    FILE_UPLOAD_FAIL(HttpStatus.BAD_REQUEST, 14004, "S3 업로드에 실패하였습니다."),
-    FILE_DELETE_FAIL(HttpStatus.BAD_REQUEST, 14005, "S3 삭제에 실패하였습니다.");
+    FILE_UPLOAD_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, 14004, "S3 업로드에 실패하였습니다."),
+    FILE_DELETE_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, 14005, "S3 삭제에 실패하였습니다.");
 
     private final HttpStatus httpStatus;
     private final Integer errorCode;

--- a/src/main/java/com/bready/server/s3/service/S3Uploader.java
+++ b/src/main/java/com/bready/server/s3/service/S3Uploader.java
@@ -1,0 +1,120 @@
+package com.bready.server.s3.service;
+
+import com.bready.server.global.exception.ApplicationException;
+import com.bready.server.s3.exception.S3ErrorCase;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+import java.io.InputStream;
+import java.util.UUID;
+
+@Slf4j
+@Service
+public class S3Uploader {
+
+    private final S3Client s3Client;
+    private final String bucket;
+    private final String region;
+    private final String prefix;
+
+    public S3Uploader(
+            S3Client s3Client,
+            @Value("${cloud.aws.s3.bucket}") String bucket,
+            @Value("${cloud.aws.region}") String region,
+            @Value("${cloud.aws.s3.public-prefix}") String prefix
+    ) {
+        this.s3Client = s3Client;
+        this.bucket = bucket;
+        this.region = region;
+        this.prefix = prefix;
+    }
+
+    public String upload(MultipartFile file, String folder) {
+        validateFile(file);
+
+        String key = buildKey(file, folder);
+
+        try (InputStream is = file.getInputStream()) {
+
+            PutObjectRequest putObjectRequest =
+                    PutObjectRequest.builder()
+                            .bucket(bucket)
+                            .key(key)
+                            .contentType(file.getContentType())
+                            .build();
+
+            s3Client.putObject(
+                    putObjectRequest,
+                    RequestBody.fromInputStream(is, file.getSize())
+            );
+
+            return buildUrl(key);
+
+        } catch (Exception e) {
+            log.error("S3 업로드 실패 key={}", key, e);
+            throw new ApplicationException(S3ErrorCase.FILE_UPLOAD_FAIL);
+        }
+    }
+
+    public void delete(String fileKey) {
+        try {
+            DeleteObjectRequest deleteObjectRequest =
+                    DeleteObjectRequest.builder()
+                            .bucket(bucket)
+                            .key(fileKey)
+                            .build();
+
+            s3Client.deleteObject(deleteObjectRequest);
+
+        } catch (Exception e) {
+            log.error("S3 삭제 실패 key={}", fileKey, e);
+            throw new ApplicationException(S3ErrorCase.FILE_DELETE_FAIL);
+        }
+    }
+
+    public String buildUrl(String key) {
+        return "https://"
+                + bucket
+                + ".s3."
+                + region
+                + ".amazonaws.com/"
+                + key;
+    }
+
+    private String buildKey(MultipartFile file, String folder) {
+
+        String filename = file.getOriginalFilename();
+        String ext = extractExtension(filename);
+
+        return prefix + "/"
+                + folder + "/"
+                + UUID.randomUUID()
+                + ext;
+    }
+
+    private void validateFile(MultipartFile file) {
+        if (file == null || file.isEmpty()) {
+            throw new ApplicationException(S3ErrorCase.EMPTY_FILE);
+        }
+
+        if (file.getOriginalFilename() == null || file.getOriginalFilename().isBlank()) {
+            throw new ApplicationException(S3ErrorCase.FILENAME_NOT_FOUND);
+        }
+    }
+
+    private String extractExtension(String filename) {
+        int idx = filename.lastIndexOf(".");
+
+        if (idx == -1 || idx == filename.length() - 1) {
+            throw new ApplicationException(S3ErrorCase.EXTENSION_NOT_FOUND);
+        }
+
+        return filename.substring(idx);
+    }
+}

--- a/src/main/java/com/bready/server/s3/service/S3Uploader.java
+++ b/src/main/java/com/bready/server/s3/service/S3Uploader.java
@@ -35,13 +35,11 @@ public class S3Uploader {
         this.prefix = prefix;
     }
 
-    public String upload(MultipartFile file, String folder) {
+    public String uploadAndReturnKey(MultipartFile file, String folder) {
         validateFile(file);
-
         String key = buildKey(file, folder);
 
         try (InputStream is = file.getInputStream()) {
-
             PutObjectRequest putObjectRequest =
                     PutObjectRequest.builder()
                             .bucket(bucket)
@@ -49,12 +47,8 @@ public class S3Uploader {
                             .contentType(file.getContentType())
                             .build();
 
-            s3Client.putObject(
-                    putObjectRequest,
-                    RequestBody.fromInputStream(is, file.getSize())
-            );
-
-            return buildUrl(key);
+            s3Client.putObject(putObjectRequest, RequestBody.fromInputStream(is, file.getSize()));
+            return key;
 
         } catch (Exception e) {
             log.error("S3 업로드 실패 key={}", key, e);

--- a/src/main/resources/application-cd.yml
+++ b/src/main/resources/application-cd.yml
@@ -32,3 +32,15 @@ oauth:
     client-id: ${NAVER_CLIENT_ID}
     client-secret: ${NAVER_CLIENT_SECRET}
     redirect-uri: ${NAVER_REDIRECT_URI}
+
+cloud:
+  aws:
+    region: ${CLOUD_AWS_REGION}
+
+    s3:
+      bucket: ${CLOUD_AWS_S3_BUCKET}
+      public-prefix: ${CLOUD_AWS_S3_PUBLIC_PREFIX}
+
+    credentials:
+      access-key: ${CLOUD_AWS_CREDENTIALS_ACCESS_KEY}
+      secret-key: ${CLOUD_AWS_CREDENTIALS_SECRET_KEY}

--- a/src/main/resources/application-ci.yml
+++ b/src/main/resources/application-ci.yml
@@ -27,3 +27,15 @@ jwt:
   secret: ${JWT_SECRET}
   access-exp: 3600000
   refresh-exp: 1209600000
+
+cloud:
+  aws:
+    region: ${CLOUD_AWS_REGION}
+
+    s3:
+      bucket: ${CLOUD_AWS_S3_BUCKET}
+      public-prefix: ${CLOUD_AWS_S3_PUBLIC_PREFIX}
+
+    credentials:
+      access-key: ${CLOUD_AWS_CREDENTIALS_ACCESS_KEY}
+      secret-key: ${CLOUD_AWS_CREDENTIALS_SECRET_KEY}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #69 

## 📝 작업 내용

**1. AWS S3 기반 이미지 저장 기능 도입**
- S3 버킷 생성 및 public/* prefix 공개 정책 적용
- CORS 설정 구성
- Spring 서버에서 S3 연동
- key 생성 규칙: {public-prefix}/{folder}/{uuid}.{ext}
- URL 생성: https://{bucket}.s3.{region}.amazonaws.com/{key}

**2. S3 테스트/검증용 API 추가**
- POST /api/v1/files/upload 
- Swagger에서 multipart/form-data 업로드 테스트 가능하도록 구성


## 🖼️ 스크린샷 (선택)
### S3 이미지 업로드 성공
<img width="1485" height="945" alt="s3업로드성공" src="https://github.com/user-attachments/assets/fd5831f5-e9b6-4196-8bc5-d718b494e5bb" />


## 💬 리뷰 요구사항 (선택)
### S3Uploader 사용 방법
이번 PR에서 구현한 S3Uploader는 각 도메인(Service 계층)에서 그대로 재사용합니다.

**1. 저장 방식**
- DB에는 url 대신 fileKey 저장을 권장
- 조회 시 URL 생성 예시: `String url = s3Uploader.buildUrl(fileKey);`

**2. 이미지 교체 흐름 (예시: 프로필 변경)**
- 새 이미지 업로드 -> DB 업데이트 -> 기존 이미지 삭제 형식으로 서비스 로직 구성하기 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 파일 업로드 API 추가: 멀티파트 파일 전송으로 업로드하고 고유 키와 공개 접근 URL을 반환합니다.

* **데이터 응답**
  * 업로드 결과를 전달하는 간결한 응답 포맷(FileKey·URL) 추가.

* **설정/배포**
  * 클라우드 스토리지 연동을 위한 런타임 설정 및 CI/CD 환경 변수(리전, 버킷, 공개 접두사, 자격증명) 추가로 배포 시 스토리지 설정 주입이 가능합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->