### PR TITLE
[feat] 플랜 상세 조회 후보/대표 연동 및 대표 자동 지정 로직 구현

### DIFF
--- a/src/main/java/com/bready/server/place/service/PlaceCandidateService.java
+++ b/src/main/java/com/bready/server/place/service/PlaceCandidateService.java
@@ -69,12 +69,7 @@ public class PlaceCandidateService {
         }
 
         if (changed) {
-            categorySelectionLogRepository.save(
-                    CategorySelectionLog.of(
-                            category.getId(),
-                            saved.getId(),
-                            LocalDateTime.now()
-                    ));
+            saveSelectionLog(category.getId(), saved.getId());
         }
 
         return PlaceCandidateCreateResponse.builder()
@@ -120,13 +115,7 @@ public class PlaceCandidateService {
             state.changeRepresentative(candidateId);
         }
 
-        categorySelectionLogRepository.save(
-                CategorySelectionLog.of(
-                        categoryId,
-                        candidateId,
-                        LocalDateTime.now()
-                )
-        );
+        saveSelectionLog(categoryId, candidateId);
 
         return PlaceCandidateRepresentativeResponse.builder()
                 .categoryId(categoryId)
@@ -156,5 +145,15 @@ public class PlaceCandidateService {
                 .candidateId(candidateId)
                 .deletedAt(candidate.getDeletedAt())
                 .build();
+    }
+
+    private void saveSelectionLog(Long categoryId, Long candidateId) {
+        categorySelectionLogRepository.save(
+                CategorySelectionLog.of(
+                        categoryId,
+                        candidateId,
+                        LocalDateTime.now()
+                )
+        );
     }
 }

--- a/src/main/java/com/bready/server/place/service/PlaceCandidateService.java
+++ b/src/main/java/com/bready/server/place/service/PlaceCandidateService.java
@@ -53,21 +53,22 @@ public class PlaceCandidateService {
                 .findByCategory_IdForUpdate(category.getId())
                 .orElse(null);
 
+        boolean changed = false;
+
         if (state == null) {
-
-            CategoryState newState = CategoryState.create(category, saved.getId());
-            categoryStateRepository.save(newState);
-
-            categorySelectionLogRepository.save(
-                    CategorySelectionLog.of(
-                            category.getId(),
-                            saved.getId(),
-                            LocalDateTime.now()
-                    )
-            );
+            try {
+                categoryStateRepository.saveAndFlush(CategoryState.create(category, saved.getId()));
+                changed = true;
+            } catch (DataIntegrityViolationException e) {
+                // 다른 트랜잭션이 먼저 생성
+                state = categoryStateRepository.findByCategory_IdForUpdate(category.getId()).orElse(null);
+            }
         } else if (state.getCurrentCandidateId() == null) {
             state.changeRepresentative(saved.getId());
+            changed = true;
+        }
 
+        if (changed) {
             categorySelectionLogRepository.save(
                     CategorySelectionLog.of(
                             category.getId(),

--- a/src/main/java/com/bready/server/place/service/PlaceCandidateService.java
+++ b/src/main/java/com/bready/server/place/service/PlaceCandidateService.java
@@ -48,6 +48,34 @@ public class PlaceCandidateService {
             throw ApplicationException.from(PlaceErrorCase.DUPLICATE_PLACE_CANDIDATE);
         }
 
+        // 대표 장소 로직 - 카테고리에서 후보가 있다면 대표 장소 보장
+        CategoryState state = categoryStateRepository
+                .findByCategory_IdForUpdate(category.getId())
+                .orElse(null);
+
+        if (state == null) {
+
+            CategoryState newState = CategoryState.create(category, saved.getId());
+            categoryStateRepository.save(newState);
+
+            categorySelectionLogRepository.save(
+                    CategorySelectionLog.of(
+                            category.getId(),
+                            saved.getId(),
+                            LocalDateTime.now()
+                    )
+            );
+        } else if (state.getCurrentCandidateId() == null) {
+            state.changeRepresentative(saved.getId());
+
+            categorySelectionLogRepository.save(
+                    CategorySelectionLog.of(
+                            category.getId(),
+                            saved.getId(),
+                            LocalDateTime.now()
+                    ));
+        }
+
         return PlaceCandidateCreateResponse.builder()
                 .candidateId(saved.getId())
                 .place(PlaceSummaryResponse.builder()

--- a/src/main/java/com/bready/server/plan/domain/PlanCategory.java
+++ b/src/main/java/com/bready/server/plan/domain/PlanCategory.java
@@ -1,11 +1,15 @@
 package com.bready.server.plan.domain;
 
 import com.bready.server.global.entity.BaseEntity;
+import com.bready.server.place.domain.PlaceCandidate;
 import com.bready.server.place.domain.PlaceCategoryType;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -27,6 +31,9 @@ public class PlanCategory extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "plan_id", nullable = false)
     private Plan plan; // plan과의 연관관계 설정 (1:N)
+
+    @OneToMany(mappedBy = "category", fetch = FetchType.LAZY)
+    private List<PlaceCandidate> candidates = new ArrayList<>();
 
     public static PlanCategory create(Plan plan, PlaceCategoryType categoryType, Integer sequence) {
         PlanCategory category = new PlanCategory();

--- a/src/main/java/com/bready/server/plan/dto/PlanDetailCandidateDto.java
+++ b/src/main/java/com/bready/server/plan/dto/PlanDetailCandidateDto.java
@@ -1,0 +1,14 @@
+package com.bready.server.plan.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class PlanDetailCandidateDto {
+
+    private Long candidateId;
+    private PlanDetailPlaceDto place;
+    private boolean isRepresentative;
+
+}

--- a/src/main/java/com/bready/server/plan/dto/PlanDetailCategoryDto.java
+++ b/src/main/java/com/bready/server/plan/dto/PlanDetailCategoryDto.java
@@ -1,0 +1,21 @@
+package com.bready.server.plan.dto;
+
+import com.bready.server.place.domain.PlaceCategoryType;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class PlanDetailCategoryDto {
+
+    private Long planCategoryId;
+    private PlaceCategoryType categoryType;
+    private Integer sequence;
+
+    private Long representativeCandidateId;
+
+    @Builder.Default
+    private List<PlanDetailCandidateDto> candidates = List.of();
+}

--- a/src/main/java/com/bready/server/plan/dto/PlanDetailPlaceDto.java
+++ b/src/main/java/com/bready/server/plan/dto/PlanDetailPlaceDto.java
@@ -1,0 +1,20 @@
+package com.bready.server.plan.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+
+@Getter
+@Builder
+public class PlanDetailPlaceDto {
+
+    private Long id;
+    private String externalId;
+    private String name;
+    private String address;
+    private BigDecimal latitude;
+    private BigDecimal longitude;
+    private Boolean isIndoor;
+
+}

--- a/src/main/java/com/bready/server/plan/dto/PlanDetailResponse.java
+++ b/src/main/java/com/bready/server/plan/dto/PlanDetailResponse.java
@@ -14,7 +14,6 @@ public class PlanDetailResponse {
     private PlanDto plan;
 
     @Builder.Default
-    private List<PlanCategoryItemDto> categories = List.of();
+    private List<PlanDetailCategoryDto> categories = List.of();
 
-    // TODO : 장소, 카테고리 등 연결
 }

--- a/src/main/java/com/bready/server/plan/repository/CategoryStateRepository.java
+++ b/src/main/java/com/bready/server/plan/repository/CategoryStateRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface CategoryStateRepository extends JpaRepository<CategoryState, Long> {
@@ -21,4 +22,7 @@ public interface CategoryStateRepository extends JpaRepository<CategoryState, Lo
     Optional<CategoryState> findByCategory_IdForUpdate(
             @Param("categoryId") Long categoryId
     );
+
+    // 플랜 상세 조회 - 대표 후보 상태 일괄 조회
+    List<CategoryState> findAllByCategory_IdIn(List<Long> categoryIds);
 }

--- a/src/main/java/com/bready/server/plan/repository/PlanCategoryRepository.java
+++ b/src/main/java/com/bready/server/plan/repository/PlanCategoryRepository.java
@@ -58,10 +58,10 @@ public interface PlanCategoryRepository extends JpaRepository<PlanCategory, Long
     select distinct pc
     from PlanCategory pc
     left join fetch pc.candidates cand
-    left join fetch cand.place p
+    left join fetch cand.place
     where pc.plan.id = :planId
       and pc.deletedAt is null
-    order by pc.sequence asc, cand.id desc
+    order by pc.sequence asc
 """)
     List<PlanCategory> findAllDetailByPlanId(@Param("planId") Long planId);
 }

--- a/src/main/java/com/bready/server/plan/repository/PlanCategoryRepository.java
+++ b/src/main/java/com/bready/server/plan/repository/PlanCategoryRepository.java
@@ -52,4 +52,16 @@ public interface PlanCategoryRepository extends JpaRepository<PlanCategory, Long
 
     // 장소 후보쪽에서 category가 plan에 속하는지 검증하기 위해서 추가
     Optional<PlanCategory> findByIdAndPlan_Id(Long id, Long planId);
+
+    // 플랜 상세 조회 - 카테고리 + 후보 + place
+    @Query("""
+    select distinct pc
+    from PlanCategory pc
+    left join fetch pc.candidates cand
+    left join fetch cand.place p
+    where pc.plan.id = :planId
+      and pc.deletedAt is null
+    order by pc.sequence asc, cand.id desc
+""")
+    List<PlanCategory> findAllDetailByPlanId(@Param("planId") Long planId);
 }

--- a/src/main/java/com/bready/server/plan/repository/PlanCategoryRepository.java
+++ b/src/main/java/com/bready/server/plan/repository/PlanCategoryRepository.java
@@ -61,6 +61,7 @@ public interface PlanCategoryRepository extends JpaRepository<PlanCategory, Long
     left join fetch cand.place
     where pc.plan.id = :planId
       and pc.deletedAt is null
+      and (cand is null or cand.deletedAt is null)
     order by pc.sequence asc
 """)
     List<PlanCategory> findAllDetailByPlanId(@Param("planId") Long planId);

--- a/src/main/java/com/bready/server/plan/service/PlanService.java
+++ b/src/main/java/com/bready/server/plan/service/PlanService.java
@@ -110,6 +110,7 @@ public class PlanService {
 
                     List<PlanDetailCandidateDto> candidateDtos =
                             category.getCandidates().stream()
+                                    .sorted((a,b) -> Long.compare(b.getId(), a.getId()))
                                     .map(candidate -> {
                                         boolean isRep = representativeId != null && representativeId.equals(candidate.getId());
 

--- a/src/main/java/com/bready/server/plan/service/PlanService.java
+++ b/src/main/java/com/bready/server/plan/service/PlanService.java
@@ -101,7 +101,8 @@ public class PlanService {
                         .stream()
                         .collect(Collectors.toMap(
                                 cs -> cs.getCategory().getId(),
-                                CategoryState::getCurrentCandidateId
+                                CategoryState::getCurrentCandidateId,
+                                (existing, replacement) -> existing
                         ));
 
         List<PlanDetailCategoryDto> categoryDtos = categories.stream()

--- a/src/main/java/com/bready/server/plan/service/PlanService.java
+++ b/src/main/java/com/bready/server/plan/service/PlanService.java
@@ -1,9 +1,12 @@
 package com.bready.server.plan.service;
 
 import com.bready.server.global.exception.ApplicationException;
+import com.bready.server.plan.domain.CategoryState;
 import com.bready.server.plan.domain.Plan;
+import com.bready.server.plan.domain.PlanCategory;
 import com.bready.server.plan.dto.*;
 import com.bready.server.plan.exception.PlanErrorCase;
+import com.bready.server.plan.repository.CategoryStateRepository;
 import com.bready.server.plan.repository.PlanCategoryRepository;
 import com.bready.server.plan.repository.PlanRepository;
 import lombok.RequiredArgsConstructor;
@@ -15,6 +18,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -22,6 +27,7 @@ public class PlanService {
 
     private final PlanRepository planRepository;
     private final PlanCategoryRepository planCategoryRepository;
+    private final CategoryStateRepository categoryStateRepository;
 
     @Transactional
     public PlanCreateResponse createPlan(Long userId, PlanCreateRequest request) {
@@ -77,19 +83,62 @@ public class PlanService {
                 .updatedAt(plan.getUpdatedAt())
                 .build();
 
-        List<PlanCategoryItemDto> categories = planCategoryRepository
-                .findAllByPlan_IdAndDeletedAtIsNullOrderBySequenceAsc(planId)
-                .stream()
-                .map(pc -> PlanCategoryItemDto.builder()
-                        .planCategoryId(pc.getId())
-                        .categoryType(pc.getCategoryType())
-                        .sequence(pc.getSequence())
-                        .build())
+        List<PlanCategory> categories = planCategoryRepository.findAllDetailByPlanId(planId);
+
+        if (categories.isEmpty()) {
+            return PlanDetailResponse.builder()
+                    .plan(planDto)
+                    .categories(List.of())
+                    .build();
+        }
+
+        List<Long> categoryIds = categories.stream()
+                .map(PlanCategory::getId)
                 .toList();
+
+        Map<Long, Long> representativeMap =
+                categoryStateRepository.findAllByCategory_IdIn(categoryIds)
+                        .stream()
+                        .collect(Collectors.toMap(
+                                cs -> cs.getCategory().getId(),
+                                CategoryState::getCurrentCandidateId
+                        ));
+
+        List<PlanDetailCategoryDto> categoryDtos = categories.stream()
+                .map(category-> {
+                    Long representativeId = representativeMap.get(category.getId());
+
+                    List<PlanDetailCandidateDto> candidateDtos =
+                            category.getCandidates().stream()
+                                    .map(candidate -> {
+                                        boolean isRep = representativeId != null && representativeId.equals(candidate.getId());
+
+                                        return PlanDetailCandidateDto.builder()
+                                                .candidateId(candidate.getId())
+                                                .isRepresentative(isRep)
+                                                .place(PlanDetailPlaceDto.builder()
+                                                        .id(candidate.getPlace().getId())
+                                                        .externalId(candidate.getPlace().getExternalId())
+                                                        .name(candidate.getPlace().getName())
+                                                        .address(candidate.getPlace().getAddress())
+                                                        .latitude(candidate.getPlace().getLatitude())
+                                                        .longitude(candidate.getPlace().getLongitude())
+                                                        .isIndoor(candidate.getPlace().getIsIndoor())
+                                                        .build())
+                                                .build();
+                                    }).toList();
+                    return PlanDetailCategoryDto.builder()
+                            .planCategoryId(category.getId())
+                            .categoryType(category.getCategoryType())
+                            .sequence(category.getSequence())
+                            .representativeCandidateId(representativeId)
+                            .candidates(candidateDtos)
+                            .build();
+                }).toList();
 
         return PlanDetailResponse.builder()
                 .plan(planDto)
-                .categories(categories)
+                .categories(categoryDtos)
                 .build();
     }
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#71 

## 📝 작업 내용

- 플랜 상세 조회 API에 카테고리별 장소 후보 목록 연동
- CategoryState 기반 대표 후보 정보 포함
- 후보 최초 추가 시 대표 후보 자동 지정 로직 추가

## 🖼️ 스크린샷 (선택)
### 플랜 상세조회 응답
<img width="1210" height="673" alt="스크린샷 2026-02-23 221601" src="https://github.com/user-attachments/assets/5b3f627e-8bad-487a-9954-52d9e3c91d9e" />

<img width="1216" height="418" alt="image" src="https://github.com/user-attachments/assets/d4ed897b-768a-49c5-a8d1-2398a9c81f1c" />

## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특히 봐주었으면 하는 부분이 있다면 작성해주세요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 플랜 상세에 각 카테고리의 후보 목록 및 후보별 위치 정보가 포함됩니다.
  * 카테고리별 대표 후보 ID가 반환되어 대표 여부를 명확히 확인할 수 있습니다.
* **버그 수정 / 개선**
  * 후보 생성·선정 시 대표 후보 유지가 안정화되고 선택 기록이 일관되게 남습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->