### PR TITLE
[fix] JVM Metaspace 메모리 설정 수정

### DIFF
--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -10,7 +10,7 @@ services:
       - "8080:8080"
     environment:
       SPRING_PROFILES_ACTIVE: cd
-      JAVA_TOOL_OPTIONS: "-Xms256m -Xmx768m -XX:MaxMetaspaceSize=128m"
+      JAVA_TOOL_OPTIONS: "-Xms256m -Xmx768m -XX:MaxMetaspaceSize=384m"
 
       DB_URL: ${DB_URL}
       DB_USERNAME: ${DB_USERNAME}

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -10,7 +10,7 @@ services:
       - "8080:8080"
     environment:
       SPRING_PROFILES_ACTIVE: cd
-      JAVA_TOOL_OPTIONS: "-Xms256m -Xmx768m -XX:MaxMetaspaceSize=384m"
+      JAVA_TOOL_OPTIONS: "-Xms256m -Xmx512m -XX:MaxMetaspaceSize=384m"
 
       DB_URL: ${DB_URL}
       DB_USERNAME: ${DB_USERNAME}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝 작업 내용

> 배포 서버에서 카카오 장소 검색 API 호출 시 JVM Metaspace 메모리 설정이 부족하여 메타데이터 로딩이 실패했기에 Metaspace 증가 시켰습니다.

## 🖼️ 스크린샷 (선택)

> UI 변경 등 시각적으로 확인할 수 있는 내용이 있다면 첨부해주세요

## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특히 봐주었으면 하는 부분이 있다면 작성해주세요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **기타 작업**
  * 프로덕션 환경의 API 서비스 JVM 메모리 설정을 조정했습니다. 이 변경으로 메모리 사용량이 재분배되어 서비스 안정성 및 메모리 효율이 향상됩니다. 기존 초기 힙 설정은 유지되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->