### PR TITLE
[feat] category recommendation API 구현

### DIFF
--- a/src/main/java/com/bready/server/recommendation/adapter/AiRerankCategoryRecommendationAdapter.java
+++ b/src/main/java/com/bready/server/recommendation/adapter/AiRerankCategoryRecommendationAdapter.java
@@ -1,5 +1,6 @@
 package com.bready.server.recommendation.adapter;
 
+import com.bready.server.place.domain.PlaceCategoryType;
 import com.bready.server.plan.domain.PlanCategory;
 import com.bready.server.recommendation.ai.AiRerankResult;
 import com.bready.server.recommendation.ai.AiRerankService;
@@ -22,17 +23,17 @@ import java.util.*;
 @ConditionalOnProperty(prefix = "recommendation.ai", name = "enabled", havingValue = "true")
 public class AiRerankCategoryRecommendationAdapter implements CategoryRecommendationPort {
 
-    private final RuleBasedCategoryRecommendationAdapter rulBasedAdapter;
+    private final RuleBasedCategoryRecommendationAdapter ruleBasedAdapter;
     private final AiRerankService aiRerankService;
 
     @Override
     public List<CategoryRecommendationResponse.CategoryItem> recommendCategories(List<PlanCategory> planCategories, PlanCategory currentCategory, TriggerType triggerType) {
-        List<CategoryRecommendationResponse.CategoryItem> base = rulBasedAdapter.recommendCategories(planCategories, currentCategory, triggerType);
+        List<CategoryRecommendationResponse.CategoryItem> base = ruleBasedAdapter.recommendCategories(planCategories, currentCategory, triggerType);
 
         if (base.isEmpty()) return base;
 
         List<CategoryRerankCandidate> targets = base.stream()
-                .map(i -> new CategoryRerankCandidate(i.categoryType().name(), i.label()))
+                .map(i -> new CategoryRerankCandidate(i.categoryType().name(), i.label(), i.categoryType()))
                 .toList();
 
         String context = buildContext(triggerType, currentCategory, planCategories);
@@ -85,10 +86,36 @@ public class AiRerankCategoryRecommendationAdapter implements CategoryRecommenda
                 .reduce((a, b) -> a + ", " + b)
                 .orElse("");
 
-        return "trigger=" + triggerType
-                + ", current=" + currentCategory.getCategoryType().name()
-                + ", planFlow=[" + flow + "]";
+        return """
+        당신은 플랜 전환 카테고리 추천 시스템이다.
+        반드시 candidates에 제공된 id만 사용해야 한다.
+        새로운 후보를 생성하면 안 된다.
+
+        추천 기준
+        - 트리거 해결에 도움이 되는 활동
+        - 현재 카테고리와 성격이 다른 활동
+        - 플랜 흐름의 다양성 유지
+
+        trigger=%s
+        current=%s
+        planFlow=[%s]
+        """.formatted(
+                triggerType,
+                currentCategory.getCategoryType().name(),
+                flow
+        );
     }
 
-    private record CategoryRerankCandidate(String id, String name) implements AiRerankTarget {}
+    private record CategoryRerankCandidate(String id, String name, PlaceCategoryType type) implements AiRerankTarget {
+        @Override
+        public Map<String, Object> toPromptAttributes() {
+            return Map.of(
+                    "id", id,
+                    "name", name,
+                    "indoor", type.isIndoor(),
+                    "keyword", type.getKeyword()
+            );
+        }
+    }
+
 }

--- a/src/main/java/com/bready/server/recommendation/adapter/AiRerankCategoryRecommendationAdapter.java
+++ b/src/main/java/com/bready/server/recommendation/adapter/AiRerankCategoryRecommendationAdapter.java
@@ -1,0 +1,94 @@
+package com.bready.server.recommendation.adapter;
+
+import com.bready.server.plan.domain.PlanCategory;
+import com.bready.server.recommendation.ai.AiRerankResult;
+import com.bready.server.recommendation.ai.AiRerankService;
+import com.bready.server.recommendation.ai.AiRerankTarget;
+import com.bready.server.recommendation.dto.CategoryRecommendationResponse;
+import com.bready.server.recommendation.port.CategoryRecommendationPort;
+import com.bready.server.trigger.domain.TriggerType;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Component;
+
+import java.util.*;
+
+@Slf4j
+@Component
+@Primary
+@RequiredArgsConstructor
+@ConditionalOnProperty(prefix = "recommendation.ai", name = "enabled", havingValue = "true")
+public class AiRerankCategoryRecommendationAdapter implements CategoryRecommendationPort {
+
+    private final RuleBasedCategoryRecommendationAdapter rulBasedAdapter;
+    private final AiRerankService aiRerankService;
+
+    @Override
+    public List<CategoryRecommendationResponse.CategoryItem> recommendCategories(List<PlanCategory> planCategories, PlanCategory currentCategory, TriggerType triggerType) {
+        List<CategoryRecommendationResponse.CategoryItem> base = rulBasedAdapter.recommendCategories(planCategories, currentCategory, triggerType);
+
+        if (base.isEmpty()) return base;
+
+        List<CategoryRerankCandidate> targets = base.stream()
+                .map(i -> new CategoryRerankCandidate(i.categoryType().name(), i.label()))
+                .toList();
+
+        String context = buildContext(triggerType, currentCategory, planCategories);
+
+        AiRerankResult result = aiRerankService.rerank(context, targets);
+        if (result == null || result.rankedIds() == null || result.rankedIds().isEmpty()) {
+            return base;
+        }
+
+        // base 기준으로 재정렬, 중복 제거
+        Map<String, CategoryRecommendationResponse.CategoryItem> itemMap = new LinkedHashMap<>();
+        for (CategoryRecommendationResponse.CategoryItem item : base) {
+            itemMap.putIfAbsent(item.categoryType().name(), item);
+        }
+
+        Set<String> added = new HashSet<>();
+        List<CategoryRecommendationResponse.CategoryItem> reordered = new ArrayList<>();
+
+        for (String id : result.rankedIds()) {
+            CategoryRecommendationResponse.CategoryItem item = itemMap.get(id);
+            if (item == null) continue;
+
+            if (!added.add(id)) continue;
+
+            String reason = (result.reasonsById() != null)
+                    ? result.reasonsById().getOrDefault(id, item.reason())
+                    : item.reason();
+
+            reordered.add(new CategoryRecommendationResponse.CategoryItem(
+                    item.categoryType(),
+                    item.label(),
+                    reason
+            ));
+        }
+
+        for (CategoryRecommendationResponse.CategoryItem item : base) {
+            String id = item.categoryType().name();
+            if (!added.contains(id)) {
+                reordered.add(item);
+            }
+        }
+
+        return reordered;
+    }
+
+    private String buildContext(TriggerType triggerType, PlanCategory currentCategory, List<PlanCategory> planCategories) {
+        String flow = planCategories.stream()
+                .sorted(Comparator.comparing(PlanCategory::getSequence))
+                .map(c -> c.getSequence() + ":" + c.getCategoryType().name())
+                .reduce((a, b) -> a + ", " + b)
+                .orElse("");
+
+        return "trigger=" + triggerType
+                + ", current=" + currentCategory.getCategoryType().name()
+                + ", planFlow=[" + flow + "]";
+    }
+
+    private record CategoryRerankCandidate(String id, String name) implements AiRerankTarget {}
+}

--- a/src/main/java/com/bready/server/recommendation/adapter/AiRerankPlaceRecommendationAdapter.java
+++ b/src/main/java/com/bready/server/recommendation/adapter/AiRerankPlaceRecommendationAdapter.java
@@ -52,6 +52,8 @@ public class AiRerankPlaceRecommendationAdapter implements PlaceRecommendationPo
         String context = buildContext(triggerType, region);
         AiRerankResult result = aiRerankService.rerank(context, targets);
 
+        if (result == null) return base;
+
         List<String> rankedIds = Optional.ofNullable(result.rankedIds()).orElse(List.of());
         if (rankedIds.isEmpty()) return base;
 

--- a/src/main/java/com/bready/server/recommendation/adapter/AiRerankPlaceRecommendationAdapter.java
+++ b/src/main/java/com/bready/server/recommendation/adapter/AiRerankPlaceRecommendationAdapter.java
@@ -52,20 +52,20 @@ public class AiRerankPlaceRecommendationAdapter implements PlaceRecommendationPo
         String context = buildContext(triggerType, region);
         AiRerankResult result = aiRerankService.rerank(context, targets);
 
-        if (result.rankedIds() == null || result.rankedIds().isEmpty()) {
-            return base;
-        }
+        List<String> rankedIds = Optional.ofNullable(result.rankedIds()).orElse(List.of());
+        if (rankedIds.isEmpty()) return base;
 
         Map<String, PlaceRecommendationResponse.RecommendationItem> itemMap =
                 base.stream().collect(Collectors.toMap(
                         PlaceRecommendationResponse.RecommendationItem::externalId,
-                        i -> i
+                        i -> i,
+                        (a,b) -> a
                 ));
 
         List<PlaceRecommendationResponse.RecommendationItem> reordered = new ArrayList<>();
         Set<String> added = new HashSet<>();
 
-        for (String id : result.rankedIds()) {
+        for (String id : rankedIds) {
             if (excludeExternalId != null && excludeExternalId.equals(id)) continue;
             PlaceRecommendationResponse.RecommendationItem item = itemMap.get(id);
             if (item != null) {

--- a/src/main/java/com/bready/server/recommendation/adapter/RuleBasedCategoryRecommendationAdapter.java
+++ b/src/main/java/com/bready/server/recommendation/adapter/RuleBasedCategoryRecommendationAdapter.java
@@ -1,0 +1,52 @@
+package com.bready.server.recommendation.adapter;
+
+import com.bready.server.place.domain.PlaceCategoryType;
+import com.bready.server.plan.domain.PlanCategory;
+import com.bready.server.recommendation.dto.CategoryRecommendationResponse;
+import com.bready.server.recommendation.port.CategoryRecommendationPort;
+import com.bready.server.trigger.domain.TriggerType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class RuleBasedCategoryRecommendationAdapter implements CategoryRecommendationPort {
+
+    @Override
+    public List<CategoryRecommendationResponse.CategoryItem> recommendCategories(List<PlanCategory> planCategories, PlanCategory currentCategory, TriggerType triggerType) {
+
+        List<CategoryRecommendationResponse.CategoryItem> result = new ArrayList<>();
+        PlaceCategoryType currentType = currentCategory.getCategoryType();
+
+        // 화이트리스트
+        for (PlaceCategoryType type : PlaceCategoryType.values()) {
+
+            if (type == currentType) continue;
+
+            if (triggerType == TriggerType.FATIGUE && type == PlaceCategoryType.WALK)  continue;
+
+            if (triggerType == TriggerType.WEATHER_BAD && !type.isIndoor()) continue;
+
+            result.add(new CategoryRecommendationResponse.CategoryItem(
+                    type,
+                    type.getLabel(),
+                    buildReason(triggerType)
+            ));
+        }
+        
+        return result;
+    }
+
+    private String buildReason(TriggerType triggerType) {
+        return switch (triggerType) {
+            case WEATHER_BAD -> "날씨 악화로 인해 실내 활동이 적합합니다.";
+            case WAITING_TOO_LONG -> "혼잡을 피할 수 있는 대체 활동입니다.";
+            case PLACE_CLOSED -> "영업 종료 상황을 고려한 대안입니다.";
+            case FATIGUE -> "체력 부담이 적은 활동을 추천합니다.";
+            case DISTANCE_TOO_FAR -> "이동 부담을 줄일 수 있는 대안입니다.";
+        };
+    }
+}

--- a/src/main/java/com/bready/server/recommendation/adapter/RuleBasedCategoryRecommendationAdapter.java
+++ b/src/main/java/com/bready/server/recommendation/adapter/RuleBasedCategoryRecommendationAdapter.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 @Component
 @RequiredArgsConstructor
@@ -18,13 +19,28 @@ public class RuleBasedCategoryRecommendationAdapter implements CategoryRecommend
     @Override
     public List<CategoryRecommendationResponse.CategoryItem> recommendCategories(List<PlanCategory> planCategories, PlanCategory currentCategory, TriggerType triggerType) {
 
-        List<CategoryRecommendationResponse.CategoryItem> result = new ArrayList<>();
         PlaceCategoryType currentType = currentCategory.getCategoryType();
+
+        PlaceCategoryType prevType = null;
+        PlaceCategoryType nextType = null;
+
+        for (int i = 0; i < planCategories.size(); i++) {
+            if (Objects.equals(planCategories.get(i).getId(), currentCategory.getId())) {
+                if (i - 1 >= 0) prevType = planCategories.get(i - 1).getCategoryType();
+                if (i + 1 < planCategories.size()) nextType = planCategories.get(i + 1).getCategoryType();
+                break;
+            }
+        }
+
+        List<CategoryRecommendationResponse.CategoryItem> result = new ArrayList<>();
 
         // 화이트리스트
         for (PlaceCategoryType type : PlaceCategoryType.values()) {
 
             if (type == currentType) continue;
+
+            if (prevType != null && type == prevType) continue;
+            if (nextType != null && type == nextType) continue;
 
             if (triggerType == TriggerType.FATIGUE && type == PlaceCategoryType.WALK)  continue;
 

--- a/src/main/java/com/bready/server/recommendation/ai/OpenAiRerankService.java
+++ b/src/main/java/com/bready/server/recommendation/ai/OpenAiRerankService.java
@@ -59,6 +59,10 @@ public class OpenAiRerankService implements AiRerankService {
                     .call()
                     .content();
 
+            content = content.replace("```json", "")
+                    .replace("```","")
+                    .trim();
+
             AiRerankResult parsed = objectMapper.readValue(content, AiRerankResult.class);
 
             if (parsed == null || parsed.rankedIds() == null || parsed.rankedIds().isEmpty()) {

--- a/src/main/java/com/bready/server/recommendation/controller/RecommendationController.java
+++ b/src/main/java/com/bready/server/recommendation/controller/RecommendationController.java
@@ -2,9 +2,8 @@ package com.bready.server.recommendation.controller;
 
 import com.bready.server.global.auth.CurrentUser;
 import com.bready.server.global.response.CommonResponse;
-import com.bready.server.recommendation.dto.PlaceRecommendationQuery;
-import com.bready.server.recommendation.dto.PlaceRecommendationRequest;
-import com.bready.server.recommendation.dto.PlaceRecommendationResponse;
+import com.bready.server.recommendation.dto.*;
+import com.bready.server.recommendation.service.CategoryRecommendationService;
 import com.bready.server.recommendation.service.PlaceRecommendationService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -24,6 +23,7 @@ import org.springframework.web.bind.annotation.*;
 public class RecommendationController {
 
     private final PlaceRecommendationService recommendationService;
+    private final CategoryRecommendationService categoryRecommendationService;
 
     @PostMapping("/places")
     @Operation(
@@ -48,5 +48,25 @@ public class RecommendationController {
             @RequestBody @Valid PlaceRecommendationRequest request
     ) {
         return CommonResponse.success(recommendationService.recommendPlaces(userId, request, query));
+    }
+
+    @PostMapping("/categories")
+    @Operation(
+            summary = "전환 카테고리 추천",
+            description = "트리거 발생 이후, 플랜 전체 흐름을 고려한 카테고리 대체 추천"
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "추천 성공",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "403", description = "플랜 접근 권한 없음",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "404", description = "플랜/카테고리/트리거 없음",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class)))
+    })
+    public CommonResponse<CategoryRecommendationResponse> recommendCategories(
+            @CurrentUser Long userId,
+            @RequestBody @Valid CategoryRecommendationRequest request
+    ) {
+        return CommonResponse.success(categoryRecommendationService.recommendCategories(userId, request));
     }
 }

--- a/src/main/java/com/bready/server/recommendation/dto/CategoryRecommendationRequest.java
+++ b/src/main/java/com/bready/server/recommendation/dto/CategoryRecommendationRequest.java
@@ -1,0 +1,9 @@
+package com.bready.server.recommendation.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+public record CategoryRecommendationRequest (
+        @NotNull Long planId,
+        @NotNull Long categoryId,
+        @NotNull Long triggerId
+){ }

--- a/src/main/java/com/bready/server/recommendation/dto/CategoryRecommendationResponse.java
+++ b/src/main/java/com/bready/server/recommendation/dto/CategoryRecommendationResponse.java
@@ -1,0 +1,9 @@
+package com.bready.server.recommendation.dto;
+
+import com.bready.server.place.domain.PlaceCategoryType;
+
+import java.util.List;
+
+public record CategoryRecommendationResponse(List<CategoryItem> items) {
+    public record CategoryItem(PlaceCategoryType categoryType, String label, String reason) {}
+}

--- a/src/main/java/com/bready/server/recommendation/port/CategoryRecommendationPort.java
+++ b/src/main/java/com/bready/server/recommendation/port/CategoryRecommendationPort.java
@@ -1,0 +1,16 @@
+package com.bready.server.recommendation.port;
+
+import com.bready.server.plan.domain.PlanCategory;
+import com.bready.server.recommendation.dto.CategoryRecommendationResponse;
+import com.bready.server.trigger.domain.TriggerType;
+
+import java.util.List;
+
+public interface CategoryRecommendationPort {
+
+    List<CategoryRecommendationResponse.CategoryItem> recommendCategories(
+            List<PlanCategory> planCategories,
+            PlanCategory currentCategory,
+            TriggerType triggerType
+    );
+}

--- a/src/main/java/com/bready/server/recommendation/service/CategoryRecommendationService.java
+++ b/src/main/java/com/bready/server/recommendation/service/CategoryRecommendationService.java
@@ -24,7 +24,7 @@ public class CategoryRecommendationService {
         RecommendValidationService.Validated v = validationService.validateUserAndLoad(userId, request);
 
         List<CategoryRecommendationResponse.CategoryItem> items = categoryRecommendationPort.recommendCategories(
-                v.planCategoreis(), v.currentCategory(), v.trigger().getTriggerType()
+                v.planCategories(), v.currentCategory(), v.trigger().getTriggerType()
         );
 
         return new CategoryRecommendationResponse(items);

--- a/src/main/java/com/bready/server/recommendation/service/CategoryRecommendationService.java
+++ b/src/main/java/com/bready/server/recommendation/service/CategoryRecommendationService.java
@@ -1,0 +1,59 @@
+package com.bready.server.recommendation.service;
+
+import com.bready.server.global.exception.ApplicationException;
+import com.bready.server.plan.domain.Plan;
+import com.bready.server.plan.domain.PlanCategory;
+import com.bready.server.plan.exception.CategoryErrorCase;
+import com.bready.server.plan.exception.PlanErrorCase;
+import com.bready.server.plan.repository.PlanCategoryRepository;
+import com.bready.server.plan.repository.PlanRepository;
+import com.bready.server.recommendation.dto.CategoryRecommendationRequest;
+import com.bready.server.recommendation.dto.CategoryRecommendationResponse;
+import com.bready.server.recommendation.port.CategoryRecommendationPort;
+import com.bready.server.trigger.domain.Trigger;
+import com.bready.server.trigger.exception.TriggerErrorCase;
+import com.bready.server.trigger.repository.TriggerRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class CategoryRecommendationService {
+
+    private final PlanRepository planRepository;
+    private final PlanCategoryRepository planCategoryRepository;
+    private final TriggerRepository triggerRepository;
+    private final CategoryRecommendationPort categoryRecommendationPort;
+
+    @Transactional(readOnly = true)
+    public CategoryRecommendationResponse recommendCategories(
+            Long userId, CategoryRecommendationRequest request
+    ) {
+        Plan plan = planRepository.findByIdAndDeletedAtIsNull(request.planId())
+                .orElseThrow(() -> new ApplicationException(PlanErrorCase.PLAN_NOT_FOUND));
+
+        if (!plan.getOwnerId().equals(userId)) {
+            throw new ApplicationException(PlanErrorCase.PLAN_ACCESS_DENIED);
+        }
+
+        PlanCategory currentCategory = planCategoryRepository.findByIdAndPlan_IdAndDeletedAtIsNull(request.categoryId(), request.planId())
+                .orElseThrow(() -> new ApplicationException(CategoryErrorCase.CATEGORY_NOT_FOUND));
+
+        Trigger trigger = triggerRepository.findById(request.triggerId())
+                .orElseThrow(() -> new ApplicationException(TriggerErrorCase.TRIGGER_NOT_FOUND));
+
+        if (!trigger.getPlan().getId().equals(request.planId()) || !trigger.getCategory().getId().equals(request.categoryId())) {
+            throw new ApplicationException(TriggerErrorCase.TRIGGER_NOT_FOUND);
+        }
+
+        List<PlanCategory> planCategories = planCategoryRepository.findAllByPlan_IdAndDeletedAtIsNullOrderBySequenceAsc(request.planId());
+
+        List<CategoryRecommendationResponse.CategoryItem> items = categoryRecommendationPort.recommendCategories(
+                planCategories, currentCategory, trigger.getTriggerType()
+        );
+        return new CategoryRecommendationResponse(items);
+    }
+}

--- a/src/main/java/com/bready/server/recommendation/service/CategoryRecommendationService.java
+++ b/src/main/java/com/bready/server/recommendation/service/CategoryRecommendationService.java
@@ -1,18 +1,8 @@
 package com.bready.server.recommendation.service;
 
-import com.bready.server.global.exception.ApplicationException;
-import com.bready.server.plan.domain.Plan;
-import com.bready.server.plan.domain.PlanCategory;
-import com.bready.server.plan.exception.CategoryErrorCase;
-import com.bready.server.plan.exception.PlanErrorCase;
-import com.bready.server.plan.repository.PlanCategoryRepository;
-import com.bready.server.plan.repository.PlanRepository;
 import com.bready.server.recommendation.dto.CategoryRecommendationRequest;
 import com.bready.server.recommendation.dto.CategoryRecommendationResponse;
 import com.bready.server.recommendation.port.CategoryRecommendationPort;
-import com.bready.server.trigger.domain.Trigger;
-import com.bready.server.trigger.exception.TriggerErrorCase;
-import com.bready.server.trigger.repository.TriggerRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -23,28 +13,18 @@ import java.util.List;
 @RequiredArgsConstructor
 public class CategoryRecommendationService {
 
-    private final PlanRepository planRepository;
-    private final PlanCategoryRepository planCategoryRepository;
-    private final TriggerRepository triggerRepository;
     private final CategoryRecommendationPort categoryRecommendationPort;
     private final RecommendValidationService validationService;
 
+    @Transactional(readOnly = true)
     public CategoryRecommendationResponse recommendCategories(
             Long userId, CategoryRecommendationRequest request
     ) {
 
-        validationService.validateUserAndLoad(userId, request);
-
-        PlanCategory currentCategory = planCategoryRepository.findByIdAndPlan_IdAndDeletedAtIsNull(request.categoryId(), request.planId())
-                .orElseThrow(() -> new ApplicationException(CategoryErrorCase.CATEGORY_NOT_FOUND));
-
-        Trigger trigger = triggerRepository.findById(request.triggerId())
-                .orElseThrow(() -> new ApplicationException(TriggerErrorCase.TRIGGER_NOT_FOUND));
-
-        List<PlanCategory> planCategories = planCategoryRepository.findAllByPlan_IdAndDeletedAtIsNullOrderBySequenceAsc(request.planId());
+        RecommendValidationService.Validated v = validationService.validateUserAndLoad(userId, request);
 
         List<CategoryRecommendationResponse.CategoryItem> items = categoryRecommendationPort.recommendCategories(
-                planCategories, currentCategory, trigger.getTriggerType()
+                v.planCategoreis(), v.currentCategory(), v.trigger().getTriggerType()
         );
 
         return new CategoryRecommendationResponse(items);

--- a/src/main/java/com/bready/server/recommendation/service/PlaceRecommendationService.java
+++ b/src/main/java/com/bready/server/recommendation/service/PlaceRecommendationService.java
@@ -68,6 +68,10 @@ public class PlaceRecommendationService {
             throw new ApplicationException(TriggerErrorCase.TRIGGER_NOT_FOUND);
         }
 
+        if (trigger.getTriggerType() == TriggerType.WEATHER_BAD && !category.getCategoryType().isIndoor()) {
+            return new PlaceRecommendationResponse(List.of());
+        }
+
         int limit = normalizeSize(query.size());
         int radius = (query.radius() != null) ? query.radius() : DEFAULT_RADIUS;
 

--- a/src/main/java/com/bready/server/recommendation/service/RecommendValidationService.java
+++ b/src/main/java/com/bready/server/recommendation/service/RecommendValidationService.java
@@ -15,6 +15,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class RecommendValidationService {
@@ -24,7 +26,7 @@ public class RecommendValidationService {
     private final TriggerRepository triggerRepository;
 
     @Transactional(readOnly = true)
-    public void validateUserAndLoad(Long userId, CategoryRecommendationRequest request) {
+    public Validated validateUserAndLoad(Long userId, CategoryRecommendationRequest request) {
 
         Plan plan = planRepository.findByIdAndDeletedAtIsNull(request.planId())
                 .orElseThrow(() -> new ApplicationException(PlanErrorCase.PLAN_NOT_FOUND));
@@ -43,6 +45,9 @@ public class RecommendValidationService {
             throw new ApplicationException(TriggerErrorCase.TRIGGER_NOT_FOUND);
         }
 
-        planCategoryRepository.findAllByPlan_IdAndDeletedAtIsNullOrderBySequenceAsc(request.planId());
+        List<PlanCategory> planCategories = planCategoryRepository.findAllByPlan_IdAndDeletedAtIsNullOrderBySequenceAsc(request.planId());
+        return new Validated(plan, currentCategory, trigger, planCategories);
     }
+
+    public record Validated(Plan plan, PlanCategory currentCategory, Trigger trigger, List<PlanCategory> planCategoreis) {}
 }

--- a/src/main/java/com/bready/server/recommendation/service/RecommendValidationService.java
+++ b/src/main/java/com/bready/server/recommendation/service/RecommendValidationService.java
@@ -38,7 +38,7 @@ public class RecommendValidationService {
         PlanCategory currentCategory = planCategoryRepository.findByIdAndPlan_IdAndDeletedAtIsNull(request.categoryId(), request.planId())
                 .orElseThrow(() -> new ApplicationException(CategoryErrorCase.CATEGORY_NOT_FOUND));
 
-        Trigger trigger = triggerRepository.findById(request.triggerId())
+        Trigger trigger = triggerRepository.findByIdAndDeletedAtIsNull(request.triggerId())
                 .orElseThrow(() -> new ApplicationException(TriggerErrorCase.TRIGGER_NOT_FOUND));
 
         if (!trigger.getPlan().getId().equals(request.planId()) || !trigger.getCategory().getId().equals(request.categoryId())) {

--- a/src/main/java/com/bready/server/recommendation/service/RecommendValidationService.java
+++ b/src/main/java/com/bready/server/recommendation/service/RecommendValidationService.java
@@ -8,8 +8,6 @@ import com.bready.server.plan.exception.PlanErrorCase;
 import com.bready.server.plan.repository.PlanCategoryRepository;
 import com.bready.server.plan.repository.PlanRepository;
 import com.bready.server.recommendation.dto.CategoryRecommendationRequest;
-import com.bready.server.recommendation.dto.CategoryRecommendationResponse;
-import com.bready.server.recommendation.port.CategoryRecommendationPort;
 import com.bready.server.trigger.domain.Trigger;
 import com.bready.server.trigger.exception.TriggerErrorCase;
 import com.bready.server.trigger.repository.TriggerRepository;
@@ -17,23 +15,23 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
-
 @Service
 @RequiredArgsConstructor
-public class CategoryRecommendationService {
+public class RecommendValidationService {
 
     private final PlanRepository planRepository;
     private final PlanCategoryRepository planCategoryRepository;
     private final TriggerRepository triggerRepository;
-    private final CategoryRecommendationPort categoryRecommendationPort;
-    private final RecommendValidationService validationService;
 
-    public CategoryRecommendationResponse recommendCategories(
-            Long userId, CategoryRecommendationRequest request
-    ) {
+    @Transactional(readOnly = true)
+    public void validateUserAndLoad(Long userId, CategoryRecommendationRequest request) {
 
-        validationService.validateUserAndLoad(userId, request);
+        Plan plan = planRepository.findByIdAndDeletedAtIsNull(request.planId())
+                .orElseThrow(() -> new ApplicationException(PlanErrorCase.PLAN_NOT_FOUND));
+
+        if (!plan.getOwnerId().equals(userId)) {
+            throw new ApplicationException(PlanErrorCase.PLAN_ACCESS_DENIED);
+        }
 
         PlanCategory currentCategory = planCategoryRepository.findByIdAndPlan_IdAndDeletedAtIsNull(request.categoryId(), request.planId())
                 .orElseThrow(() -> new ApplicationException(CategoryErrorCase.CATEGORY_NOT_FOUND));
@@ -41,12 +39,10 @@ public class CategoryRecommendationService {
         Trigger trigger = triggerRepository.findById(request.triggerId())
                 .orElseThrow(() -> new ApplicationException(TriggerErrorCase.TRIGGER_NOT_FOUND));
 
-        List<PlanCategory> planCategories = planCategoryRepository.findAllByPlan_IdAndDeletedAtIsNullOrderBySequenceAsc(request.planId());
+        if (!trigger.getPlan().getId().equals(request.planId()) || !trigger.getCategory().getId().equals(request.categoryId())) {
+            throw new ApplicationException(TriggerErrorCase.TRIGGER_NOT_FOUND);
+        }
 
-        List<CategoryRecommendationResponse.CategoryItem> items = categoryRecommendationPort.recommendCategories(
-                planCategories, currentCategory, trigger.getTriggerType()
-        );
-
-        return new CategoryRecommendationResponse(items);
+        planCategoryRepository.findAllByPlan_IdAndDeletedAtIsNullOrderBySequenceAsc(request.planId());
     }
 }

--- a/src/main/java/com/bready/server/recommendation/service/RecommendValidationService.java
+++ b/src/main/java/com/bready/server/recommendation/service/RecommendValidationService.java
@@ -49,5 +49,5 @@ public class RecommendValidationService {
         return new Validated(plan, currentCategory, trigger, planCategories);
     }
 
-    public record Validated(Plan plan, PlanCategory currentCategory, Trigger trigger, List<PlanCategory> planCategoreis) {}
+    public record Validated(Plan plan, PlanCategory currentCategory, Trigger trigger, List<PlanCategory> planCategories) {}
 }

--- a/src/main/java/com/bready/server/trigger/repository/TriggerRepository.java
+++ b/src/main/java/com/bready/server/trigger/repository/TriggerRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 public interface TriggerRepository extends JpaRepository<Trigger, Long> {
     interface TriggerTypeCount {
@@ -42,4 +43,6 @@ public interface TriggerRepository extends JpaRepository<Trigger, Long> {
       and (:from is null or t.occurredAt >= :from)
     """)
     long countByPlanIdAndPeriod(@Param("planId") Long planId, @Param("from") LocalDateTime from);
+
+    Optional<Trigger> findByIdAndDeletedAtIsNull(Long id);
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#83 

## 📝 작업 내용

- 트리거 유형에 따른 카테고리 필터 정책 적용 (WEATHER_BAD..)
- 룰 기반 후보 생성 후 AI 를 통한 추천 순서 재정렬 구조 적용
  - 현재 카테고리 및 인접 카테고리 연속 선택 방지 로직 적용
- AI rerank context에 플랜 흐름 및 트리거 정보 전달

## 🖼️ 스크린샷 (선택)
<img width="921" height="755" alt="스크린샷 2026-03-04 185413" src="https://github.com/user-attachments/assets/8f131a5f-6294-400d-a0fb-745ed1a739b0" />

## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특히 봐주었으면 하는 부분이 있다면 작성해주세요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 카테고리 추천 전용 API 엔드포인트 추가
  * 룰 기반 추천 제공 및 AI 기반 재정렬을 결합한 카테고리 추천 흐름 도입
  * 추천 요청/응답 DTO, 포트와 서비스, 검증 로직 및 추천 서비스 추가

* **버그 수정**
  * AI 응답의 코드펜스 제거로 JSON 파싱 안정성 개선
  * 악천후 시 실외 카테고리에 대한 추천을 조기 차단하도록 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->