### PR TITLE
[refactor] 전체 통계 API 테스트 후 리팩토링 및 최종 점검 진행 

### DIFF
--- a/src/main/java/com/bready/server/plan/repository/PlanCategoryRepository.java
+++ b/src/main/java/com/bready/server/plan/repository/PlanCategoryRepository.java
@@ -33,39 +33,28 @@ public interface PlanCategoryRepository extends JpaRepository<PlanCategory, Long
     List<PlanCategory> findAllByPlan_IdAndDeletedAtIsNullOrderBySequenceAsc(Long planId);
 
     @Query("""
-    select pc
-    from PlanCategory pc
-    where pc.plan.id = :planId
-      and pc.deletedAt is null
-    order by pc.sequence desc
-""")
-    List<PlanCategory> findLastByPlanId(@Param("planId") Long planId, Pageable pageable);
-
-
-    // planIds로만 category 조회 (성능 개선)
-    @Query("""
-        select
-            pc.plan.id as planId,
-            pc.categoryType as categoryType
+        select pc
         from PlanCategory pc
-        where pc.plan.id in :planIds
+        where pc.plan.id = :planId
+          and pc.deletedAt is null
+        order by pc.sequence desc
     """)
-    List<PlanCategoryTypeRow> findCategoryTypesByPlanIds(@Param("planIds") List<Long> planIds);
+    List<PlanCategory> findLastByPlanId(@Param("planId") Long planId, Pageable pageable);
 
     // 장소 후보쪽에서 category가 plan에 속하는지 검증하기 위해서 추가
     Optional<PlanCategory> findByIdAndPlan_Id(Long id, Long planId);
 
     // 플랜 상세 조회 - 카테고리 + 후보 + place
     @Query("""
-    select distinct pc
-    from PlanCategory pc
-    left join fetch pc.candidates cand
-    left join fetch cand.place
-    where pc.plan.id = :planId
-      and pc.deletedAt is null
-      and (cand is null or cand.deletedAt is null)
-    order by pc.sequence asc
-""")
+        select distinct pc
+        from PlanCategory pc
+        left join fetch pc.candidates cand
+        left join fetch cand.place
+        where pc.plan.id = :planId
+          and pc.deletedAt is null
+          and (cand is null or cand.deletedAt is null)
+        order by pc.sequence asc
+    """)
     List<PlanCategory> findAllDetailByPlanId(@Param("planId") Long planId);
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
@@ -80,4 +69,15 @@ public interface PlanCategoryRepository extends JpaRepository<PlanCategory, Long
             @Param("planCategoryId") Long planCategoryId,
             @Param("planId") Long planId
     );
+
+    @Query("""
+        select
+            pc.plan.id as planId,
+            pc.categoryType as categoryType
+        from PlanCategory pc
+        where pc.plan.id in :planIds
+          and pc.deletedAt is null
+        order by pc.plan.id asc, pc.sequence asc
+    """)
+    List<PlanCategoryTypeRow> findCategoryTypesByPlanIds(@Param("planIds") List<Long> planIds);
 }

--- a/src/main/java/com/bready/server/plan/repository/PlanRepository.java
+++ b/src/main/java/com/bready/server/plan/repository/PlanRepository.java
@@ -29,28 +29,6 @@ public interface PlanRepository extends JpaRepository<Plan, Long> {
         Long getTotalSwitches();
     }
 
-    /*
-    @Query("""
-                select
-                    p.id as planId,
-                    p.title as planTitle,
-                    p.planDate as planDate,
-                    p.region as region,
-                    count(sl.id) as totalSwitches
-                from Plan p
-                left join Trigger t on t.plan = p
-                left join Decision d on d.trigger = t
-                left join SwitchLog sl on sl.decision = d
-                where p.ownerId = :ownerId
-                group by p.id, p.title, p.planDate, p.region
-                order by p.planDate desc
-            """)
-    List<PlanSwitchStatsRow> findPlanSwitchStats(
-            @Param("ownerId") Long ownerId,
-            Pageable pageable
-    );
-     */
-
     @Query("""
                 select p
                 from Plan p
@@ -60,12 +38,12 @@ public interface PlanRepository extends JpaRepository<Plan, Long> {
     Optional<Plan> findByIdAndOwnerId(@Param("planId") Long planId, @Param("ownerId") Long ownerId);
 
     @Query("""
-                select count(p)
-                from Plan p
-                where p.ownerId = :ownerId
-                            and p.deletedAt is null
-            """)
-    long countByOwnerId(@Param("ownerId") Long ownerId);
+        select count(p)
+            from Plan p
+        where p.ownerId = :ownerId
+            and p.deletedAt is null
+    """)
+    long countActiveByOwnerId(@Param("ownerId") Long ownerId);
 
     // 조회용 - 락 없음
     Optional<Plan> findByIdAndDeletedAtIsNull(Long id);
@@ -105,6 +83,4 @@ public interface PlanRepository extends JpaRepository<Plan, Long> {
       and p.deletedAt is null
 """)
     Optional<Plan> findByIdAndDeletedAtIsNullForUpdate(@Param("id") Long id);
-
-
 }

--- a/src/main/java/com/bready/server/stats/controller/PlanStatsController.java
+++ b/src/main/java/com/bready/server/stats/controller/PlanStatsController.java
@@ -4,9 +4,9 @@ import com.bready.server.global.auth.CurrentUser;
 import com.bready.server.global.response.CommonResponse;
 import com.bready.server.stats.domain.StatsPeriod;
 import com.bready.server.stats.dto.PlanStatsResponse;
-import com.bready.server.stats.service.PlanStatsJoinService;
 import com.bready.server.stats.service.PlanStatsMaterializedService;
 import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
 import org.springframework.validation.annotation.Validated;
@@ -14,7 +14,6 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import jakarta.validation.constraints.NotNull;
 
 
 @RestController
@@ -22,59 +21,14 @@ import jakarta.validation.constraints.NotNull;
 @RequestMapping("/api/v1/stats")
 @Validated
 public class PlanStatsController {
-
-    private final PlanStatsJoinService joinService;
     private final PlanStatsMaterializedService materializedService;
 
-    /*
     @GetMapping("/plans")
-    @Operation(
-            summary = "플랜별 통계 목록 조회",
-            description = "현재 로그인 사용자가 생성한 모든 플랜을 대상으로, 플랜별 전환 횟수 및 기본 정보를 조회합니다."
-    )
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "조회 성공",
-                    content = @Content(schema = @Schema(implementation = CommonResponse.class))
-            ),
-            @ApiResponse(responseCode = "401", description = "요청 파라미터가 올바르지 않습니다.",
-                    content = @Content(schema = @Schema(implementation = CommonResponse.class))
-            )
-    })
     public CommonResponse<PlanStatsResponse> getPlanStats(
-            @Parameter(hidden = true)
-            @CurrentUser Long ownerId,
-            @Parameter(description = "조회 기간 (WEEK | MONTH | ALL)", example = "ALL")
-            @RequestParam @NotNull StatsPeriod period,
-            @Parameter(description = "목록 개수 (기본 20, 최대 50)", example = "20")
-            @RequestParam(required = false) @Positive @Max(50) Integer limit
-    ) {
-        return CommonResponse.success(planStatsJoinService.getPlanStats(ownerId, period, limit));
-    }
-     */
-
-    // JOIN 기반 조회
-    @GetMapping("/plans/join")
-    public CommonResponse<PlanStatsResponse> getJoinStats(
             @CurrentUser Long ownerId,
             @RequestParam @NotNull StatsPeriod period,
             @RequestParam(required = false) @Positive @Max(50) Integer limit
     ) {
-
-        return CommonResponse.success(
-                joinService.getStats(ownerId, period, limit)
-        );
-    }
-
-    // Materialized 조회
-    @GetMapping("/plans/materialized")
-    public CommonResponse<PlanStatsResponse> getMaterializedStats(
-            @CurrentUser Long ownerId,
-            @RequestParam @NotNull StatsPeriod period,
-            @RequestParam(required = false) @Positive @Max(50) Integer limit
-    ) {
-
-        return CommonResponse.success(
-                materializedService.getStats(ownerId, period, limit)
-        );
+        return CommonResponse.success(materializedService.getStats(ownerId, period, limit));
     }
 }

--- a/src/main/java/com/bready/server/stats/controller/RecentActivityStatsController.java
+++ b/src/main/java/com/bready/server/stats/controller/RecentActivityStatsController.java
@@ -38,7 +38,7 @@ public class RecentActivityStatsController {
                     content = @Content(schema = @Schema(implementation = CommonResponse.class))),
             @ApiResponse(responseCode = "400", description = "period 값이 잘못됨",
                     content = @Content(schema = @Schema(implementation = CommonResponse.class))),
-            @ApiResponse(responseCode = "409", description = "limit 값 오류",
+            @ApiResponse(responseCode = "400", description = "limit 값 오류",
                     content = @Content(schema = @Schema(implementation = CommonResponse.class)))
     })
     public CommonResponse<RecentActivitiesResponse> getRecentActivities(

--- a/src/main/java/com/bready/server/stats/controller/RecentActivityStatsController.java
+++ b/src/main/java/com/bready/server/stats/controller/RecentActivityStatsController.java
@@ -1,0 +1,53 @@
+package com.bready.server.stats.controller;
+
+import com.bready.server.global.auth.CurrentUser;
+import com.bready.server.global.response.CommonResponse;
+import com.bready.server.stats.domain.StatsPeriod;
+import com.bready.server.stats.dto.RecentActivitiesResponse;
+import com.bready.server.stats.service.RecentActivityStatsService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.Parameter;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Positive;
+import lombok.RequiredArgsConstructor;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/stats")
+@Validated
+public class RecentActivityStatsController {
+
+    private final RecentActivityStatsService recentActivityStatsService;
+
+    @GetMapping("/activities")
+    @Operation(
+            summary = "전체 최근 활동 로그 조회",
+            description = "현재 로그인 사용자의 전체 플랜 기준 최근 활동 로그를 최신순으로 조회합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "400", description = "period 값이 잘못됨",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "409", description = "limit 값 오류",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class)))
+    })
+    public CommonResponse<RecentActivitiesResponse> getRecentActivities(
+            @CurrentUser Long userId,
+            @Parameter(description = "조회 기간 (WEEK | MONTH | ALL)", example = "ALL")
+            @RequestParam StatsPeriod period,
+            @Parameter(description = "최근 N개 (기본 3, 최대 20)", example = "3")
+            @RequestParam(required = false) @Positive @Max(20) Integer limit
+    ) {
+        return CommonResponse.success(recentActivityStatsService.getRecentActivities(userId, period, limit));
+    }
+}

--- a/src/main/java/com/bready/server/stats/dto/RecentActivitiesResponse.java
+++ b/src/main/java/com/bready/server/stats/dto/RecentActivitiesResponse.java
@@ -1,0 +1,14 @@
+package com.bready.server.stats.dto;
+
+import com.bready.server.stats.domain.StatsPeriod;
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record RecentActivitiesResponse(
+        StatsPeriod period,
+        int limit,
+        List<RecentActivityItem> items
+) {
+}

--- a/src/main/java/com/bready/server/stats/dto/RecentActivityItem.java
+++ b/src/main/java/com/bready/server/stats/dto/RecentActivityItem.java
@@ -1,0 +1,18 @@
+package com.bready.server.stats.dto;
+
+import com.bready.server.trigger.domain.DecisionType;
+import com.bready.server.trigger.domain.TriggerType;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Builder
+public record RecentActivityItem(
+        String activityId,
+        Long planId,
+        String planTitle,
+        TriggerType triggerType,
+        DecisionType decisionType,
+        LocalDateTime createdAt
+) {
+}

--- a/src/main/java/com/bready/server/stats/service/PlanActivityStatsService.java
+++ b/src/main/java/com/bready/server/stats/service/PlanActivityStatsService.java
@@ -37,7 +37,7 @@ public class PlanActivityStatsService {
         Plan plan = planRepository.findByIdAndOwnerId(planId, ownerId)
                 .orElseThrow(() -> ApplicationException.from(StatsErrorCase.INVALID_PARAMETER));
 
-        PageRequest pageable = PageRequest.of(0, limit);
+        PageRequest pageable = PageRequest.of(0, limit * 2);
 
         List<SwitchLogRepository.SwitchActivityRow> switchRows =
                 switchLogRepository.findRecentSwitchActivities(ownerId, planId, pageable);

--- a/src/main/java/com/bready/server/stats/service/RecentActivityStatsService.java
+++ b/src/main/java/com/bready/server/stats/service/RecentActivityStatsService.java
@@ -1,0 +1,104 @@
+package com.bready.server.stats.service;
+
+import com.bready.server.global.exception.ApplicationException;
+import com.bready.server.stats.domain.StatsPeriod;
+import com.bready.server.stats.dto.RecentActivitiesResponse;
+import com.bready.server.stats.dto.RecentActivityItem;
+import com.bready.server.stats.exception.StatsErrorCase;
+import com.bready.server.trigger.domain.DecisionType;
+import com.bready.server.trigger.repository.DecisionRepository;
+import com.bready.server.trigger.repository.SwitchLogRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Comparator;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class RecentActivityStatsService {
+
+    private static final int DEFAULT_LIMIT = 3;
+    private static final int MAX_LIMIT = 20;
+
+    private final SwitchLogRepository switchLogRepository;
+    private final DecisionRepository decisionRepository;
+
+    public RecentActivitiesResponse getRecentActivities(
+            Long ownerId,
+            StatsPeriod period,
+            Integer limitParam
+    ) {
+        int limit = normalizeLimit(limitParam);
+        LocalDateTime startAt = resolveStartAt(period);
+
+        PageRequest pageable = PageRequest.of(0, limit * 2);
+
+        List<SwitchLogRepository.RecentSwitchActivityRow> switchRows =
+                switchLogRepository.findRecentSwitchActivitiesAllPlans(ownerId, startAt, pageable);
+
+        List<DecisionRepository.RecentKeepActivityRow> keepRows =
+                decisionRepository.findRecentKeepActivities(ownerId, startAt, pageable);
+
+        List<RecentActivityItem> merged = new ArrayList<>();
+
+        for (SwitchLogRepository.RecentSwitchActivityRow row : switchRows) {
+            merged.add(
+                    RecentActivityItem.builder()
+                            .activityId("SWITCH-" + row.getLogId())
+                            .planId(row.getPlanId())
+                            .planTitle(row.getPlanTitle())
+                            .triggerType(row.getTriggerType())
+                            .decisionType(DecisionType.SWITCH)
+                            .createdAt(row.getCreatedAt())
+                            .build()
+            );
+        }
+
+        for (DecisionRepository.RecentKeepActivityRow row : keepRows) {
+            merged.add(
+                    RecentActivityItem.builder()
+                            .activityId("KEEP-" + row.getDecisionId())
+                            .planId(row.getPlanId())
+                            .planTitle(row.getPlanTitle())
+                            .triggerType(row.getTriggerType())
+                            .decisionType(DecisionType.KEEP)
+                            .createdAt(row.getCreatedAt())
+                            .build()
+            );
+        }
+
+        List<RecentActivityItem> items = merged.stream()
+                .sorted(Comparator.comparing(RecentActivityItem::createdAt).reversed())
+                .limit(limit)
+                .toList();
+
+        return RecentActivitiesResponse.builder()
+                .period(period)
+                .limit(limit)
+                .items(items)
+                .build();
+    }
+
+    private int normalizeLimit(Integer limitParam) {
+        int limit = (limitParam == null) ? DEFAULT_LIMIT : limitParam;
+        if (limit <= 0 || limit > MAX_LIMIT) {
+            throw ApplicationException.from(StatsErrorCase.INVALID_LIMIT);
+        }
+        return limit;
+    }
+
+    private LocalDateTime resolveStartAt(StatsPeriod period) {
+        LocalDateTime now = LocalDateTime.now();
+        return switch (period) {
+            case WEEK -> now.minusWeeks(1);
+            case MONTH -> now.minusMonths(1);
+            case ALL -> null;
+        };
+    }
+}

--- a/src/main/java/com/bready/server/stats/service/StatsService.java
+++ b/src/main/java/com/bready/server/stats/service/StatsService.java
@@ -26,7 +26,7 @@ public class StatsService {
 
         LocalDateTime startAt = resolveStartAt(period);
 
-        long totalPlans = planRepository.countByOwnerId(ownerId);
+        long totalPlans = planRepository.countActiveByOwnerId(ownerId);
         long totalSwitches = switchLogRepository.countByOwnerIdAndPeriod(ownerId, startAt);
         long recentCount = decisionRepository.countByOwnerIdAndPeriod(ownerId, startAt);
 

--- a/src/main/java/com/bready/server/stats/service/StatsService.java
+++ b/src/main/java/com/bready/server/stats/service/StatsService.java
@@ -3,8 +3,8 @@ package com.bready.server.stats.service;
 import com.bready.server.plan.repository.PlanRepository;
 import com.bready.server.stats.domain.StatsPeriod;
 import com.bready.server.stats.dto.StatsSummaryResponse;
+import com.bready.server.trigger.repository.DecisionRepository;
 import com.bready.server.trigger.repository.SwitchLogRepository;
-import com.bready.server.trigger.repository.TriggerRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,7 +20,7 @@ public class StatsService {
 
     private final PlanRepository planRepository;
     private final SwitchLogRepository switchLogRepository;
-    private final TriggerRepository triggerRepository;
+    private final DecisionRepository decisionRepository;
 
     public StatsSummaryResponse getSummary(Long ownerId, StatsPeriod period) {
 
@@ -28,7 +28,7 @@ public class StatsService {
 
         long totalPlans = planRepository.countByOwnerId(ownerId);
         long totalSwitches = switchLogRepository.countByOwnerIdAndPeriod(ownerId, startAt);
-        long recentCount = triggerRepository.countByOwnerIdAndPeriod(ownerId, startAt);
+        long recentCount = decisionRepository.countByOwnerIdAndPeriod(ownerId, startAt);
 
         double avgSwitchesPerPlan = calculateAvg(totalSwitches, totalPlans);
 

--- a/src/main/java/com/bready/server/trigger/repository/DecisionRepository.java
+++ b/src/main/java/com/bready/server/trigger/repository/DecisionRepository.java
@@ -51,4 +51,17 @@ public interface DecisionRepository extends JpaRepository<Decision, Long> {
             @Param("decisionType") DecisionType decisionType,
             Pageable pageable
     );
+
+    @Query("""
+        select count(d)
+        from Decision d
+        join d.trigger t
+        join t.plan p
+        where p.ownerId = :ownerId
+            and (:startAt is null or d.decidedAt >= :startAt)
+    """)
+    long countByOwnerIdAndPeriod(
+            @Param("ownerId") Long ownerId,
+            @Param("startAt") LocalDateTime startAt
+    );
 }

--- a/src/main/java/com/bready/server/trigger/repository/DecisionRepository.java
+++ b/src/main/java/com/bready/server/trigger/repository/DecisionRepository.java
@@ -19,6 +19,15 @@ public interface DecisionRepository extends JpaRepository<Decision, Long> {
         LocalDateTime getCreatedAt();
     }
 
+    interface RecentKeepActivityRow {
+        Long getDecisionId();
+        Long getPlanId();
+        String getPlanTitle();
+        TriggerType getTriggerType();
+        LocalDateTime getCreatedAt();
+    }
+
+
     boolean existsByTrigger_Id(Long triggerId);
     Optional<Decision> findByTrigger_Id(Long triggerId);
 
@@ -63,5 +72,27 @@ public interface DecisionRepository extends JpaRepository<Decision, Long> {
     long countByOwnerIdAndPeriod(
             @Param("ownerId") Long ownerId,
             @Param("startAt") LocalDateTime startAt
+    );
+
+    @Query("""
+        select
+            d.id as decisionId,
+            p.id as planId,
+            p.title as planTitle,
+            t.triggerType as triggerType,
+            d.decidedAt as createdAt
+        from Decision d
+        join d.trigger t
+        join t.plan p
+        where p.ownerId = :ownerId
+          and p.deletedAt is null
+          and d.decisionType = com.bready.server.trigger.domain.DecisionType.KEEP
+          and (:startAt is null or d.decidedAt >= :startAt)
+        order by d.decidedAt desc
+    """)
+    List<RecentKeepActivityRow> findRecentKeepActivities(
+            @Param("ownerId") Long ownerId,
+            @Param("startAt") LocalDateTime startAt,
+            Pageable pageable
     );
 }

--- a/src/main/java/com/bready/server/trigger/repository/SwitchLogRepository.java
+++ b/src/main/java/com/bready/server/trigger/repository/SwitchLogRepository.java
@@ -17,6 +17,14 @@ public interface SwitchLogRepository extends JpaRepository<SwitchLog, Long> {
         LocalDateTime getCreatedAt();
     }
 
+    interface RecentSwitchActivityRow {
+        Long getLogId();
+        Long getPlanId();
+        String getPlanTitle();
+        TriggerType getTriggerType();
+        LocalDateTime getCreatedAt();
+    }
+
     @Query("""
         select
             sl.id as logId,
@@ -56,6 +64,28 @@ public interface SwitchLogRepository extends JpaRepository<SwitchLog, Long> {
           and (:from is null or sl.createdAt >= :from)
     """)
     long countSwitchByPlanIdAndPeriod(@Param("planId") Long planId, @Param("from") LocalDateTime from);
+
+    @Query("""
+        select
+            sl.id as logId,
+            p.id as planId,
+            p.title as planTitle,
+            t.triggerType as triggerType,
+            sl.createdAt as createdAt
+        from SwitchLog sl
+        join sl.decision d
+        join d.trigger t
+        join t.plan p
+        where p.ownerId = :ownerId
+          and p.deletedAt is null
+          and (:startAt is null or sl.createdAt >= :startAt)
+        order by sl.createdAt desc
+    """)
+    List<RecentSwitchActivityRow> findRecentSwitchActivitiesAllPlans(
+            @Param("ownerId") Long ownerId,
+            @Param("startAt") LocalDateTime startAt,
+            Pageable pageable
+    );
 
     boolean existsByDecision_Id(Long decisionId);
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #86 

## 📝 작업 내용

> 통계 관련한 모든 API에 대해서 잘 동작하는지 최종 점검하고, 틀리거나 안되는 부분에 대한 fix 및 refactor 진행
> 플랜 전체 활동 로그가 필요하여 API 구현 

## 🖼️ 스크린샷 (선택)
### 통계 관련 Swagger 테스트 
<img width="1470" height="943" alt="6666" src="https://github.com/user-attachments/assets/c0e3ebc7-7911-4144-821b-c81361a955ff" />

<img width="1487" height="948" alt="7777" src="https://github.com/user-attachments/assets/32b70f58-6195-433d-b511-6ca070db815e" />

<img width="1474" height="903" alt="8888" src="https://github.com/user-attachments/assets/36009392-4aa0-4af5-ad16-58a126c3ba9a" />




## 💬 리뷰 요구사항 (선택)

> 일단 다 잘되는거 같은데 프론트 연동해보고 제대로 안되는건 그때그때 다시 고칠 예정입니다. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 최근 활동 통계 조회 추가 — 기간별(주/월/전체)로 최근 활동 항목 제공(한도 및 검증 포함)
  * 여러 계획의 카테고리 유형 일괄 조회 지원

* **Refactor**
  * 계획 통계 API 정리 — 조인 기반 경로 제거, 머티리얼라이즈드 경로만 유지
  * 활동 조회 로직 개선 — 더 큰 풀에서 병합·정렬 후 제한 적용하여 정확도 향상
<!-- end of auto-generated comment: release notes by coderabbit.ai -->