### PR TITLE
[feat] 유저 닉네임,자기소개,프로필 이미지 변경 API 구현 

### DIFF
--- a/src/main/java/com/bready/server/user/controller/UserController.java
+++ b/src/main/java/com/bready/server/user/controller/UserController.java
@@ -12,7 +12,9 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequestMapping("/api/v1/users")
@@ -71,5 +73,23 @@ public class UserController {
     ) {
         userService.updateBio(userId, request.bio());
         return CommonResponse.success(null);
+    }
+
+    @PatchMapping(value = "/profile/image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @Operation(summary = "프로필 이미지 변경", description = "JWT 인증된 사용자의 프로필 이미지를 변경합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "수정 성공",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "401", description = "인증 필요",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "404", description = "사용자 없음",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class)))
+    })
+    public CommonResponse<String> updateProfileImage(
+            @CurrentUser Long userId,
+            @RequestPart("file") MultipartFile file
+    ) {
+        String imageUrl = userService.updateProfileImage(userId, file);
+        return CommonResponse.success(imageUrl);
     }
 }

--- a/src/main/java/com/bready/server/user/controller/UserController.java
+++ b/src/main/java/com/bready/server/user/controller/UserController.java
@@ -11,6 +11,7 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
@@ -51,7 +52,7 @@ public class UserController {
     })
     public CommonResponse<Void> updateNickname(
             @CurrentUser Long userId,
-            @RequestBody UpdateNicknameRequest request
+            @Valid @RequestBody UpdateNicknameRequest request
     ) {
         userService.updateNickname(userId, request.nickname());
         return CommonResponse.success(null);
@@ -69,7 +70,7 @@ public class UserController {
     })
     public CommonResponse<Void> updateBio(
             @CurrentUser Long userId,
-            @RequestBody UpdateBioRequest request
+            @Valid @RequestBody UpdateBioRequest request
     ) {
         userService.updateBio(userId, request.bio());
         return CommonResponse.success(null);

--- a/src/main/java/com/bready/server/user/controller/UserController.java
+++ b/src/main/java/com/bready/server/user/controller/UserController.java
@@ -1,7 +1,10 @@
 package com.bready.server.user.controller;
 
+import com.bready.server.global.auth.CurrentUser;
 import com.bready.server.global.exception.ApplicationException;
 import com.bready.server.global.response.CommonResponse;
+import com.bready.server.user.dto.UpdateBioRequest;
+import com.bready.server.user.dto.UpdateNicknameRequest;
 import com.bready.server.user.dto.UserProfileDto;
 import com.bready.server.user.exception.UserErrorCase;
 import com.bready.server.user.service.UserService;
@@ -13,9 +16,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/v1/users")
@@ -42,5 +43,41 @@ public class UserController {
         }
 
         return CommonResponse.success(userService.getMyProfile(userId));
+    }
+
+    @PatchMapping("/profile/nickname")
+    @Operation(summary = "닉네임 수정", description = "JWT 인증된 사용자의 닉네임을 수정합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "수정 성공",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "401", description = "인증 필요",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "404", description = "사용자 없음",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class)))
+    })
+    public CommonResponse<Void> updateNickname(
+            @CurrentUser Long userId,
+            @RequestBody UpdateNicknameRequest request
+    ) {
+        userService.updateNickname(userId, request.nickname());
+        return CommonResponse.success(null);
+    }
+
+    @PatchMapping("/profile/bio")
+    @Operation(summary = "자기소개 수정", description = "JWT 인증된 사용자의 자기소개를 수정합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "수정 성공",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "401", description = "인증 필요",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "404", description = "사용자 없음",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class)))
+    })
+    public CommonResponse<Void> updateBio(
+            @CurrentUser Long userId,
+            @RequestBody UpdateBioRequest request
+    ) {
+        userService.updateBio(userId, request.bio());
+        return CommonResponse.success(null);
     }
 }

--- a/src/main/java/com/bready/server/user/controller/UserController.java
+++ b/src/main/java/com/bready/server/user/controller/UserController.java
@@ -1,12 +1,10 @@
 package com.bready.server.user.controller;
 
 import com.bready.server.global.auth.CurrentUser;
-import com.bready.server.global.exception.ApplicationException;
 import com.bready.server.global.response.CommonResponse;
 import com.bready.server.user.dto.UpdateBioRequest;
 import com.bready.server.user.dto.UpdateNicknameRequest;
 import com.bready.server.user.dto.UserProfileDto;
-import com.bready.server.user.exception.UserErrorCase;
 import com.bready.server.user.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -14,8 +12,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -35,13 +31,9 @@ public class UserController {
             @ApiResponse(responseCode = "404", description = "사용자 없음",
                 content = @Content(schema = @Schema(implementation = CommonResponse.class)))
     })
-    public CommonResponse<UserProfileDto> me() {
-
-        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-        if (auth == null || !(auth.getPrincipal() instanceof Long userId)) {
-            throw new ApplicationException(UserErrorCase.AUTH_REQUIRED);
-        }
-
+    public CommonResponse<UserProfileDto> me(
+            @CurrentUser Long userId
+    ) {
         return CommonResponse.success(userService.getMyProfile(userId));
     }
 

--- a/src/main/java/com/bready/server/user/domain/UserProfile.java
+++ b/src/main/java/com/bready/server/user/domain/UserProfile.java
@@ -30,4 +30,12 @@ public class UserProfile {
         user.setUserProfile(profile);
         return profile;
     }
+
+    public void changeNickname(String nickname) {
+        this.nickname = nickname;
+    }
+
+    public void changeBio(String bio) {
+        this.bio = bio;
+    }
 }

--- a/src/main/java/com/bready/server/user/domain/UserProfile.java
+++ b/src/main/java/com/bready/server/user/domain/UserProfile.java
@@ -12,6 +12,9 @@ public class UserProfile {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Version
+    private Long version;
+
     private String nickname;
 
     private String bio;

--- a/src/main/java/com/bready/server/user/domain/UserProfile.java
+++ b/src/main/java/com/bready/server/user/domain/UserProfile.java
@@ -38,4 +38,8 @@ public class UserProfile {
     public void changeBio(String bio) {
         this.bio = bio;
     }
+
+    public void changeProfileImage(String profileImageUrl) {
+        this.profileImageUrl = profileImageUrl;
+    }
 }

--- a/src/main/java/com/bready/server/user/dto/UpdateBioRequest.java
+++ b/src/main/java/com/bready/server/user/dto/UpdateBioRequest.java
@@ -1,0 +1,9 @@
+package com.bready.server.user.dto;
+
+import jakarta.validation.constraints.Size;
+
+public record UpdateBioRequest(
+        @Size(max = 200)
+        String bio
+) {
+}

--- a/src/main/java/com/bready/server/user/dto/UpdateNicknameRequest.java
+++ b/src/main/java/com/bready/server/user/dto/UpdateNicknameRequest.java
@@ -1,0 +1,11 @@
+package com.bready.server.user.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record UpdateNicknameRequest(
+        @NotBlank
+        @Size(max = 20)
+        String nickname
+) {
+}

--- a/src/main/java/com/bready/server/user/service/UserService.java
+++ b/src/main/java/com/bready/server/user/service/UserService.java
@@ -56,22 +56,14 @@ public class UserService {
 
     @Transactional
     public void updateNickname(Long userId, String nickname) {
-
-        User user = userRepository.findByIdWithProfile(userId)
-                .orElseThrow(() -> new ApplicationException(UserErrorCase.USER_NOT_FOUND));
-
-        UserProfile profile = user.getUserProfile();
+        UserProfile profile = getUserProfile(userId);
 
         profile.changeNickname(nickname);
     }
 
     @Transactional
     public void updateBio(Long userId, String bio) {
-
-        User user = userRepository.findByIdWithProfile(userId)
-                .orElseThrow(() -> new ApplicationException(UserErrorCase.USER_NOT_FOUND));
-
-        UserProfile profile = user.getUserProfile();
+        UserProfile profile = getUserProfile(userId);
 
         profile.changeBio(bio);
     }
@@ -84,10 +76,7 @@ public class UserService {
         }
 
         // 사용자 조회
-        User user = userRepository.findByIdWithProfile(userId)
-                .orElseThrow(() -> new ApplicationException(UserErrorCase.USER_NOT_FOUND));
-
-        UserProfile profile = user.getUserProfile();
+        UserProfile profile = getUserProfile(userId);
 
         // 기존 이미지 URL 저장
         String oldImageUrl = profile.getProfileImageUrl();
@@ -115,6 +104,13 @@ public class UserService {
         if (index == -1) { return null;}
 
         return url.substring(index + ".amazonaws.com/".length());
+    }
+
+    private UserProfile getUserProfile(Long userId) {
+        User user = userRepository.findByIdWithProfile(userId)
+                .orElseThrow(() -> new ApplicationException(UserErrorCase.USER_NOT_FOUND));
+
+        return user.getUserProfile();
     }
 }
 

--- a/src/main/java/com/bready/server/user/service/UserService.java
+++ b/src/main/java/com/bready/server/user/service/UserService.java
@@ -70,12 +70,6 @@ public class UserService {
 
     @Transactional
     public String updateProfileImage(Long userId, MultipartFile file) {
-
-        if (userId == null) {
-            throw new ApplicationException(UserErrorCase.AUTH_REQUIRED);
-        }
-
-        // 사용자 조회
         UserProfile profile = getUserProfile(userId);
 
         // 기존 이미지 URL 저장
@@ -83,16 +77,19 @@ public class UserService {
 
         // 새 이미지 업로드
         String fileKey = s3Uploader.uploadAndReturnKey(file, "profiles");
+
         String url = s3Uploader.buildUrl(fileKey);
 
         profile.changeProfileImage(url);
 
         if (oldImageUrl != null && !oldImageUrl.isBlank()) {
             String oldKey = extractKeyFromUrl(oldImageUrl);
-            if (oldKey != null) try {
-                s3Uploader.delete(oldKey);
-            } catch (Exception e) {
-                log.warn("기존 프로필 이미지 삭제 실패: {}", oldKey, e);
+            if (oldKey != null) {
+                try {
+                    s3Uploader.delete(oldKey);
+                } catch (Exception e) {
+                    log.warn("기존 프로필 이미지 삭제 실패: {}", oldKey, e);
+                }
             }
         }
         return url;

--- a/src/main/java/com/bready/server/user/service/UserService.java
+++ b/src/main/java/com/bready/server/user/service/UserService.java
@@ -48,5 +48,27 @@ public class UserService {
                 .joinedAt(joinedAt)
                 .build();
     }
+
+    @Transactional
+    public void updateNickname(Long userId, String nickname) {
+
+        User user = userRepository.findByIdWithProfile(userId)
+                .orElseThrow(() -> new ApplicationException(UserErrorCase.USER_NOT_FOUND));
+
+        UserProfile profile = user.getUserProfile();
+
+        profile.changeNickname(nickname);
+    }
+
+    @Transactional
+    public void updateBio(Long userId, String bio) {
+
+        User user = userRepository.findByIdWithProfile(userId)
+                .orElseThrow(() -> new ApplicationException(UserErrorCase.USER_NOT_FOUND));
+
+        UserProfile profile = user.getUserProfile();
+
+        profile.changeBio(bio);
+    }
 }
 

--- a/src/main/java/com/bready/server/user/service/UserService.java
+++ b/src/main/java/com/bready/server/user/service/UserService.java
@@ -1,6 +1,7 @@
 package com.bready.server.user.service;
 
 import com.bready.server.global.exception.ApplicationException;
+import com.bready.server.s3.service.S3Uploader;
 import com.bready.server.user.domain.User;
 import com.bready.server.user.domain.UserProfile;
 import com.bready.server.user.dto.UserProfileDto;
@@ -9,6 +10,7 @@ import com.bready.server.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
@@ -19,6 +21,7 @@ import java.time.format.DateTimeFormatter;
 public class UserService {
 
     private final UserRepository userRepository;
+    private final S3Uploader s3Uploader;
 
     public UserProfileDto getMyProfile(Long userId) {
         if (userId == null) {
@@ -69,6 +72,48 @@ public class UserService {
         UserProfile profile = user.getUserProfile();
 
         profile.changeBio(bio);
+    }
+
+    @Transactional
+    public String updateProfileImage(Long userId, MultipartFile file) {
+
+        if (userId == null) {
+            throw new ApplicationException(UserErrorCase.AUTH_REQUIRED);
+        }
+
+        // 사용자 조회
+        User user = userRepository.findByIdWithProfile(userId)
+                .orElseThrow(() -> new ApplicationException(UserErrorCase.USER_NOT_FOUND));
+
+        UserProfile profile = user.getUserProfile();
+
+        // 기존 이미지 삭제 (있을 경우)
+        if (profile.getProfileImageUrl() != null && !profile.getProfileImageUrl().isBlank()) {
+
+            String oldKey = extractKeyFromUrl(profile.getProfileImageUrl());
+
+            if (oldKey != null) {
+                s3Uploader.delete(oldKey);
+            }
+        }
+
+        // 새 이미지 업로드
+        String fileKey = s3Uploader.uploadAndReturnKey(file, "profiles");
+
+        // 공개 URL 생성
+        String url = s3Uploader.buildUrl(fileKey);
+
+        profile.changeProfileImage(url);
+
+        return url;
+    }
+
+    private String extractKeyFromUrl(String url) {
+        int index = url.indexOf(".amazonaws.com/");
+
+        if (index == -1) { return null;}
+
+        return url.substring(index + ".amazonaws.com/".length());
     }
 }
 

--- a/src/main/java/com/bready/server/user/service/UserService.java
+++ b/src/main/java/com/bready/server/user/service/UserService.java
@@ -8,6 +8,7 @@ import com.bready.server.user.dto.UserProfileDto;
 import com.bready.server.user.exception.UserErrorCase;
 import com.bready.server.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -15,6 +16,7 @@ import org.springframework.web.multipart.MultipartFile;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -87,24 +89,23 @@ public class UserService {
 
         UserProfile profile = user.getUserProfile();
 
-        // 기존 이미지 삭제 (있을 경우)
-        if (profile.getProfileImageUrl() != null && !profile.getProfileImageUrl().isBlank()) {
-
-            String oldKey = extractKeyFromUrl(profile.getProfileImageUrl());
-
-            if (oldKey != null) {
-                s3Uploader.delete(oldKey);
-            }
-        }
+        // 기존 이미지 URL 저장
+        String oldImageUrl = profile.getProfileImageUrl();
 
         // 새 이미지 업로드
         String fileKey = s3Uploader.uploadAndReturnKey(file, "profiles");
-
-        // 공개 URL 생성
         String url = s3Uploader.buildUrl(fileKey);
 
         profile.changeProfileImage(url);
 
+        if (oldImageUrl != null && !oldImageUrl.isBlank()) {
+            String oldKey = extractKeyFromUrl(oldImageUrl);
+            if (oldKey != null) try {
+                s3Uploader.delete(oldKey);
+            } catch (Exception e) {
+                log.warn("기존 프로필 이미지 삭제 실패: {}", oldKey, e);
+            }
+        }
         return url;
     }
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #88 

## 📝 작업 내용

> 유저 마이페이지 UI에서 필요한 유저가 본인의 닉네임,자기소개,프로필 이미지를 변경할 수 있도록 해당 API들을 구현했습니다.
1. 유저 닉네임 변경 API (PATCH` /api/v1/users/profile/nickname`)
2. 유저 자기소개 변경 API (PATCH `/api/v1/users/profile/bio`)
3. 유저 프로필 이미지 변경 API (PATCH `/api/v1/users/profile/image`)

## 🖼️ 스크린샷 (선택)
### 유저 닉네임 변경 성공
<img width="1458" height="945" alt="닉네임수정성공" src="https://github.com/user-attachments/assets/09e8d7a6-8503-4765-ad82-c302c96e0316" />

### 유저 자기소개 변경 성공
<img width="1468" height="946" alt="자기소개수정성공" src="https://github.com/user-attachments/assets/484989c7-cbc4-4210-a001-08ed9de86cd1" />

### 유저 프로필 이미지 변경 성공
<img width="1466" height="943" alt="유저프로필이미지수정성공" src="https://github.com/user-attachments/assets/cc7ee87c-6327-428d-8821-b1ff18a593e1" />


## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특히 봐주었으면 하는 부분이 있다면 작성해주세요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 프로필 정보 관리 기능 강화
    * 닉네임 변경 가능(최대 20자)
    * 자기소개 변경 가능(최대 200자)
    * 프로필 이미지 업로드 및 변경 가능(파일 업로드 지원)
  * 프로필 변경 시 변경된 이미지의 새 URL이 반환되어 즉시 확인 가능
<!-- end of auto-generated comment: release notes by coderabbit.ai -->