### PR TITLE
[test] 플랜, S3 관련 컨트롤러,서비스 로직 테스트코드 구현 

### DIFF
--- a/src/main/java/com/bready/server/global/exception/ApplicationException.java
+++ b/src/main/java/com/bready/server/global/exception/ApplicationException.java
@@ -20,4 +20,12 @@ public class ApplicationException extends RuntimeException {
     public static ApplicationException from(ErrorCase errorCase) {
         return new ApplicationException(errorCase);
     }
+
+    public Integer getErrorCode() {
+        return errorCase.getErrorCode();
+    }
+
+    public Integer getHttpStatusCode() {
+        return errorCase.getHttpStatusCode();
+    }
 }

--- a/src/main/java/com/bready/server/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/bready/server/global/exception/GlobalExceptionHandler.java
@@ -1,18 +1,19 @@
 package com.bready.server.global.exception;
 
 import com.bready.server.global.response.CommonResponse;
-import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 import com.bready.server.stats.exception.StatsErrorCase;
+import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
-import org.springframework.validation.ObjectError;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.validation.ObjectError;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
@@ -121,12 +122,30 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(MethodArgumentTypeMismatchException.class)
-    public CommonResponse<Void> handleTypeMismatch(MethodArgumentTypeMismatchException e) {
+    public CommonResponse<?> handleTypeMismatch(MethodArgumentTypeMismatchException e) {
 
         if ("period".equals(e.getName())) {
             throw ApplicationException.from(StatsErrorCase.INVALID_PERIOD);
         }
 
         throw e;
+    }
+
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    public ResponseEntity<CommonResponse<?>> handleMissingServletRequestParameterException(
+            MissingServletRequestParameterException e) {
+
+        return ResponseEntity
+                .badRequest()
+                .body(CommonResponse.error(400, "필수 요청 파라미터가 누락되었습니다."));
+    }
+
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<CommonResponse<?>> handleConstraintViolationException(
+            ConstraintViolationException e) {
+
+        return ResponseEntity
+                .badRequest()
+                .body(CommonResponse.error(400, "요청 값이 유효하지 않습니다."));
     }
 }

--- a/src/main/java/com/bready/server/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/bready/server/global/exception/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.bready.server.global.exception;
 
 import com.bready.server.global.response.CommonResponse;
+import com.bready.server.s3.exception.S3ErrorCase;
 import com.bready.server.stats.exception.StatsErrorCase;
 import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -17,6 +18,7 @@ import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.multipart.support.MissingServletRequestPartException;
 import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 @Slf4j
@@ -147,5 +149,14 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .badRequest()
                 .body(CommonResponse.error(400, "요청 값이 유효하지 않습니다."));
+    }
+
+    @ExceptionHandler(MissingServletRequestPartException.class)
+    public ResponseEntity<CommonResponse<?>> handleMissingPart(
+            MissingServletRequestPartException e
+    ) {
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(CommonResponse.error(S3ErrorCase.FILE_REQUIRED.getErrorCode(), S3ErrorCase.FILE_REQUIRED.getMessage()));
     }
 }

--- a/src/main/java/com/bready/server/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/bready/server/global/exception/GlobalExceptionHandler.java
@@ -21,6 +21,8 @@ import org.springframework.web.method.annotation.MethodArgumentTypeMismatchExcep
 import org.springframework.web.multipart.support.MissingServletRequestPartException;
 import org.springframework.web.servlet.resource.NoResourceFoundException;
 
+import static org.springframework.http.ResponseEntity.status;
+
 @Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
@@ -28,8 +30,7 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(ApplicationException.class)
     public ResponseEntity<CommonResponse<?>> handleApplicationException(ApplicationException e) {
         log.warn("[ApplicationException] {}", e.getMessage());
-        return ResponseEntity
-                .status(e.getErrorCase().getHttpStatusCode())
+        return status(e.getErrorCase().getHttpStatusCode())
                 .body(CommonResponse.error(e.getErrorCase()));
     }
 
@@ -43,8 +44,7 @@ public class GlobalExceptionHandler {
                 .orElse("요청 값이 유효하지 않습니다.");
 
         log.warn("[ValidationException] {}", message);
-        return ResponseEntity
-                .status(HttpStatus.BAD_REQUEST)
+        return status(HttpStatus.BAD_REQUEST)
                 .body(CommonResponse.error(4001, message));
     }
 
@@ -60,35 +60,30 @@ public class GlobalExceptionHandler {
             log.warn("[HttpMessageNotReadable] {}", e.getMessage());
 
             if ("planDate".equals(fieldName)) {
-                return ResponseEntity
-                        .status(HttpStatus.BAD_REQUEST)
+                return status(HttpStatus.BAD_REQUEST)
                         .body(CommonResponse.error(4006, "planDate 형식이 올바르지 않습니다."));
             }
 
-            return ResponseEntity
-                    .status(HttpStatus.BAD_REQUEST)
+            return status(HttpStatus.BAD_REQUEST)
                     .body(CommonResponse.error(4001, "요청 값이 유효하지 않습니다."));
         }
 
         log.warn("[HttpMessageNotReadable] {}", e.getMessage());
-        return ResponseEntity
-                .status(HttpStatus.BAD_REQUEST)
+        return status(HttpStatus.BAD_REQUEST)
                 .body(CommonResponse.error(4001, "요청 값이 유효하지 않습니다."));
     }
 
     @ExceptionHandler(AuthenticationException.class)
     public ResponseEntity<CommonResponse<?>> handleAuthenticationException(AuthenticationException e) {
         log.warn("[AuthenticationException] {}", e.getMessage());
-        return ResponseEntity
-                .status(HttpStatus.UNAUTHORIZED)
+        return status(HttpStatus.UNAUTHORIZED)
                 .body(CommonResponse.error(401, "로그인이 필요합니다."));
     }
 
     @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
     public ResponseEntity<CommonResponse<?>> handleMethodNotSupported(HttpRequestMethodNotSupportedException e) {
         log.warn("[MethodNotAllowed] {}", e.getMessage());
-        return ResponseEntity
-                .status(HttpStatus.METHOD_NOT_ALLOWED)
+        return status(HttpStatus.METHOD_NOT_ALLOWED)
                 .body(CommonResponse.error(405, "허용되지 않은 HTTP 메소드입니다."));
     }
 
@@ -102,8 +97,7 @@ public class GlobalExceptionHandler {
                 e.getMessage()
         );
 
-        return ResponseEntity
-                .status(HttpStatus.NOT_FOUND)
+        return status(HttpStatus.NOT_FOUND)
                 .body(CommonResponse.error(404, "요청하신 리소스를 찾을 수 없습니다."));
     }
 
@@ -118,13 +112,12 @@ public class GlobalExceptionHandler {
         }
 
         log.error("[UnexpectedException]", e);
-        return ResponseEntity
-                .status(HttpStatus.INTERNAL_SERVER_ERROR)
+        return status(HttpStatus.INTERNAL_SERVER_ERROR)
                 .body(CommonResponse.error(500, "서버 내부 오류가 발생했습니다."));
     }
 
     @ExceptionHandler(MethodArgumentTypeMismatchException.class)
-    public CommonResponse<?> handleTypeMismatch(MethodArgumentTypeMismatchException e) {
+    public ResponseEntity<CommonResponse<?>> handleTypeMismatch(MethodArgumentTypeMismatchException e) {
 
         if ("period".equals(e.getName())) {
             throw ApplicationException.from(StatsErrorCase.INVALID_PERIOD);
@@ -136,6 +129,7 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(MissingServletRequestParameterException.class)
     public ResponseEntity<CommonResponse<?>> handleMissingServletRequestParameterException(
             MissingServletRequestParameterException e) {
+        log.warn("[MissingServletRequestParameterException] parameter={}", e.getParameterName());
 
         return ResponseEntity
                 .badRequest()
@@ -145,7 +139,7 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(ConstraintViolationException.class)
     public ResponseEntity<CommonResponse<?>> handleConstraintViolationException(
             ConstraintViolationException e) {
-
+        log.warn("[ConstraintViolationException] {}", e.getMessage());
         return ResponseEntity
                 .badRequest()
                 .body(CommonResponse.error(400, "요청 값이 유효하지 않습니다."));
@@ -155,8 +149,17 @@ public class GlobalExceptionHandler {
     public ResponseEntity<CommonResponse<?>> handleMissingPart(
             MissingServletRequestPartException e
     ) {
-        return ResponseEntity
-                .status(HttpStatus.BAD_REQUEST)
-                .body(CommonResponse.error(S3ErrorCase.FILE_REQUIRED.getErrorCode(), S3ErrorCase.FILE_REQUIRED.getMessage()));
+        log.warn("[MissingServletRequestPartException] partName={}", e.getRequestPartName());
+
+        // S3 파일 업로드 관련 part인 경우
+        if ("file".equals(e.getRequestPartName())) {
+            return ResponseEntity
+                    .status(HttpStatus.BAD_REQUEST)
+                    .body(CommonResponse.error(S3ErrorCase.FILE_REQUIRED));
+        }
+
+        // 그 외 일반적인 multipart 누락
+        return status(HttpStatus.BAD_REQUEST)
+                .body(CommonResponse.error(400, "필수 요청 파트가 누락되었습니다: " + e.getRequestPartName()));
     }
 }

--- a/src/main/java/com/bready/server/plan/dto/PlanCreateRequest.java
+++ b/src/main/java/com/bready/server/plan/dto/PlanCreateRequest.java
@@ -3,10 +3,12 @@ package com.bready.server.plan.dto;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
 
 @Getter
+@NoArgsConstructor
 public class PlanCreateRequest {
 
     @NotBlank(message = "플랜 제목을 입력해주세요.")

--- a/src/main/java/com/bready/server/plan/dto/PlanCreateRequest.java
+++ b/src/main/java/com/bready/server/plan/dto/PlanCreateRequest.java
@@ -17,4 +17,10 @@ public class PlanCreateRequest {
 
     @NotBlank(message = "지역 정보를 입력해주세요.")
     private String region;
+
+    public PlanCreateRequest(String title, LocalDate planDate, String region) {
+        this.title = title;
+        this.planDate = planDate;
+        this.region = region;
+    }
 }

--- a/src/main/java/com/bready/server/plan/dto/PlanUpdateRequest.java
+++ b/src/main/java/com/bready/server/plan/dto/PlanUpdateRequest.java
@@ -18,4 +18,9 @@ public class PlanUpdateRequest {
     @NotBlank(message = "지역 정보를 입력해주세요.")
     private String region;
 
+    public PlanUpdateRequest(String title, LocalDate planDate, String region) {
+        this.title = title;
+        this.planDate = planDate;
+        this.region = region;
+    }
 }

--- a/src/main/java/com/bready/server/plan/dto/PlanUpdateRequest.java
+++ b/src/main/java/com/bready/server/plan/dto/PlanUpdateRequest.java
@@ -3,10 +3,12 @@ package com.bready.server.plan.dto;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
 
 @Getter
+@NoArgsConstructor
 public class PlanUpdateRequest {
 
     @NotBlank(message = "플랜 제목을 입력해주세요.")

--- a/src/main/java/com/bready/server/s3/exception/S3ErrorCase.java
+++ b/src/main/java/com/bready/server/s3/exception/S3ErrorCase.java
@@ -12,7 +12,8 @@ public enum S3ErrorCase implements ErrorCase {
     EXTENSION_NOT_FOUND(HttpStatus.BAD_REQUEST, 14003, "확장자가 없는 파일은 업로드할 수 없습니다."),
 
     FILE_UPLOAD_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, 14004, "S3 업로드에 실패하였습니다."),
-    FILE_DELETE_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, 14005, "S3 삭제에 실패하였습니다.");
+    FILE_DELETE_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, 14005, "S3 삭제에 실패하였습니다."),
+    FILE_REQUIRED(HttpStatus.BAD_REQUEST, 14006, "파일이 필요합니다.");
 
     private final HttpStatus httpStatus;
     private final Integer errorCode;

--- a/src/test/java/com/bready/server/global/config/TestConfig.java
+++ b/src/test/java/com/bready/server/global/config/TestConfig.java
@@ -7,6 +7,7 @@ import org.springframework.web.bind.support.WebDataBinderFactory;
 import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import java.util.List;
@@ -30,8 +31,12 @@ public class TestConfig implements WebMvcConfigurer {
                     NativeWebRequest webRequest,
                     WebDataBinderFactory binderFactory
             ) {
-                return 1L; // 항상 userId 1로 고정
+                return 1L;
             }
         });
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
     }
 }

--- a/src/test/java/com/bready/server/global/config/TestConfig.java
+++ b/src/test/java/com/bready/server/global/config/TestConfig.java
@@ -1,0 +1,37 @@
+package com.bready.server.global.config;
+
+import com.bready.server.global.auth.CurrentUser;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.core.MethodParameter;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@TestConfiguration
+public class TestConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(new HandlerMethodArgumentResolver() {
+
+            @Override
+            public boolean supportsParameter(MethodParameter parameter) {
+                return parameter.hasParameterAnnotation(CurrentUser.class);
+            }
+
+            @Override
+            public Object resolveArgument(
+                    MethodParameter parameter,
+                    ModelAndViewContainer mavContainer,
+                    NativeWebRequest webRequest,
+                    WebDataBinderFactory binderFactory
+            ) {
+                return 1L; // 항상 userId 1로 고정
+            }
+        });
+    }
+}

--- a/src/test/java/com/bready/server/place/controller/PlaceSearchControllerTest.java
+++ b/src/test/java/com/bready/server/place/controller/PlaceSearchControllerTest.java
@@ -92,4 +92,37 @@ class PlaceSearchControllerTest {
                 .andExpect(jsonPath("$.errorCode")
                         .value(PlaceErrorCase.PLACE_NOT_FOUND.getErrorCode()));
     }
+
+    @Test
+    @DisplayName("category 누락 → 400")
+    void search_category_missing() throws Exception {
+
+        mockMvc.perform(get("/api/v1/places/search")
+                        .param("latitude", "37.544")
+                        .param("longitude", "127.055"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("radius 범위 초과 → 400")
+    void search_radius_invalid() throws Exception {
+
+        mockMvc.perform(get("/api/v1/places/search")
+                        .param("category", "CAFE")
+                        .param("latitude", "37.544")
+                        .param("longitude", "127.055")
+                        .param("radius", "20000"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("위도 범위 초과 → 400")
+    void search_latitude_invalid() throws Exception {
+
+        mockMvc.perform(get("/api/v1/places/search")
+                        .param("category", "CAFE")
+                        .param("latitude", "200")
+                        .param("longitude", "127"))
+                .andExpect(status().isBadRequest());
+    }
 }

--- a/src/test/java/com/bready/server/plan/controller/PlanControllerTest.java
+++ b/src/test/java/com/bready/server/plan/controller/PlanControllerTest.java
@@ -109,7 +109,8 @@ class PlanControllerTest {
         mockMvc.perform(post("/api/v1/plans")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{}"))
-                .andExpect(status().isBadRequest());
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").value(4001));
     }
 
     @Test

--- a/src/test/java/com/bready/server/plan/controller/PlanControllerTest.java
+++ b/src/test/java/com/bready/server/plan/controller/PlanControllerTest.java
@@ -1,0 +1,4 @@
+package com.bready.server.plan.controller;
+
+public class PlanControllerTest {
+}

--- a/src/test/java/com/bready/server/plan/controller/PlanControllerTest.java
+++ b/src/test/java/com/bready/server/plan/controller/PlanControllerTest.java
@@ -1,4 +1,263 @@
 package com.bready.server.plan.controller;
 
-public class PlanControllerTest {
+import com.bready.server.global.auth.CurrentUser;
+import com.bready.server.global.exception.ApplicationException;
+import com.bready.server.global.exception.GlobalExceptionHandler;
+import com.bready.server.plan.dto.PlanCreateResponse;
+import com.bready.server.plan.dto.PlanDeleteResponse;
+import com.bready.server.plan.dto.PlanDetailResponse;
+import com.bready.server.plan.dto.PlanDto;
+import com.bready.server.plan.dto.PlanListItemDto;
+import com.bready.server.plan.dto.PlanListResponse;
+import com.bready.server.plan.dto.PlanUpdateResponse;
+import com.bready.server.plan.exception.PlanErrorCase;
+import com.bready.server.plan.service.PlanService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(MockitoExtension.class)
+class PlanControllerTest {
+
+    private MockMvc mockMvc;
+
+    @Mock
+    private PlanService planService;
+
+    @InjectMocks
+    private PlanController planController;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(planController)
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .setCustomArgumentResolvers(new HandlerMethodArgumentResolver() {
+                    @Override
+                    public boolean supportsParameter(MethodParameter parameter) {
+                        return parameter.hasParameterAnnotation(CurrentUser.class)
+                                && parameter.getParameterType().equals(Long.class);
+                    }
+
+                    @Override
+                    public Object resolveArgument(
+                            MethodParameter parameter,
+                            ModelAndViewContainer mavContainer,
+                            NativeWebRequest webRequest,
+                            WebDataBinderFactory binderFactory
+                    ) {
+                        return 1L;
+                    }
+                })
+                .build();
+    }
+
+    @Test
+    @DisplayName("플랜 생성 성공 → 201")
+    void createPlan_success() throws Exception {
+        String requestJson = """
+                {
+                  "title": "서울 여행",
+                  "planDate": "2026-03-20",
+                  "region": "서울"
+                }
+                """;
+
+        PlanCreateResponse response = PlanCreateResponse.builder()
+                .planId(10L)
+                .createdAt(LocalDateTime.now())
+                .build();
+
+        given(planService.createPlan(anyLong(), any()))
+                .willReturn(response);
+
+        mockMvc.perform(post("/api/v1/plans")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestJson))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.data.planId").value(10L));
+    }
+
+    @Test
+    @DisplayName("플랜 생성 validation 실패 → 400")
+    void createPlan_validation_fail() throws Exception {
+        mockMvc.perform(post("/api/v1/plans")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("플랜 수정 성공 → 200")
+    void updatePlan_success() throws Exception {
+        String requestJson = """
+                {
+                  "title": "부산 여행",
+                  "planDate": "2026-03-18",
+                  "region": "부산"
+                }
+                """;
+
+        PlanUpdateResponse response = PlanUpdateResponse.builder()
+                .planId(10L)
+                .updatedAt(LocalDateTime.now())
+                .build();
+
+        given(planService.updatePlan(anyLong(), anyLong(), any()))
+                .willReturn(response);
+
+        mockMvc.perform(patch("/api/v1/plans/10")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestJson))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.planId").value(10L));
+    }
+
+    @Test
+    @DisplayName("플랜 수정 - 없음 → 404")
+    void updatePlan_not_found() throws Exception {
+        String requestJson = """
+                {
+                  "title": "test",
+                  "planDate": "2026-03-20",
+                  "region": "서울"
+                }
+                """;
+
+        given(planService.updatePlan(anyLong(), anyLong(), any()))
+                .willThrow(ApplicationException.from(PlanErrorCase.PLAN_NOT_FOUND));
+
+        mockMvc.perform(patch("/api/v1/plans/10")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestJson))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.errorCode").value(PlanErrorCase.PLAN_NOT_FOUND.getErrorCode()));
+    }
+
+    @Test
+    @DisplayName("플랜 수정 - 권한 없음 → 403")
+    void updatePlan_access_denied() throws Exception {
+        String requestJson = """
+                {
+                  "title": "test",
+                  "planDate": "2026-03-20",
+                  "region": "서울"
+                }
+                """;
+
+        given(planService.updatePlan(anyLong(), anyLong(), any()))
+                .willThrow(ApplicationException.from(PlanErrorCase.PLAN_ACCESS_DENIED));
+
+        mockMvc.perform(patch("/api/v1/plans/10")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestJson))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.errorCode").value(PlanErrorCase.PLAN_ACCESS_DENIED.getErrorCode()));
+    }
+
+    @Test
+    @DisplayName("플랜 상세 조회 성공 → 200")
+    void getPlanDetail_success() throws Exception {
+        PlanDto planDto = PlanDto.builder()
+                .planId(10L)
+                .title("서울 여행")
+                .build();
+
+        PlanDetailResponse response = PlanDetailResponse.builder()
+                .plan(planDto)
+                .categories(List.of())
+                .build();
+
+        given(planService.getPlanDetail(anyLong(), anyLong()))
+                .willReturn(response);
+
+        mockMvc.perform(get("/api/v1/plans/10"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.plan.planId").value(10L))
+                .andExpect(jsonPath("$.data.plan.title").value("서울 여행"));
+    }
+
+    @Test
+    @DisplayName("플랜 상세 조회 - 없음 → 404")
+    void getPlanDetail_not_found() throws Exception {
+        given(planService.getPlanDetail(anyLong(), anyLong()))
+                .willThrow(ApplicationException.from(PlanErrorCase.PLAN_NOT_FOUND));
+
+        mockMvc.perform(get("/api/v1/plans/10"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.errorCode").value(PlanErrorCase.PLAN_NOT_FOUND.getErrorCode()));
+    }
+
+    @Test
+    @DisplayName("내 플랜 목록 조회 → 200")
+    void getMyPlans_success() throws Exception {
+        PlanListItemDto item = PlanListItemDto.builder()
+                .planId(10L)
+                .title("서울 여행")
+                .build();
+
+        PlanListResponse response = PlanListResponse.builder()
+                .items(List.of(item))
+                .pageInfo(null)
+                .build();
+
+        given(planService.getMyPlans(anyLong(), anyInt(), anyInt(), any()))
+                .willReturn(response);
+
+        mockMvc.perform(get("/api/v1/plans"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.items[0].planId").value(10L))
+                .andExpect(jsonPath("$.data.items[0].title").value("서울 여행"));
+    }
+
+    @Test
+    @DisplayName("플랜 삭제 성공 → 200")
+    void deletePlan_success() throws Exception {
+        PlanDeleteResponse response = PlanDeleteResponse.builder()
+                .planId(10L)
+                .build();
+
+        given(planService.deletePlan(anyLong(), anyLong()))
+                .willReturn(response);
+
+        mockMvc.perform(delete("/api/v1/plans/10"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.planId").value(10L));
+    }
+
+    @Test
+    @DisplayName("플랜 삭제 - 권한 없음 → 403")
+    void deletePlan_access_denied() throws Exception {
+        given(planService.deletePlan(anyLong(), anyLong()))
+                .willThrow(ApplicationException.from(PlanErrorCase.PLAN_ACCESS_DENIED));
+
+        mockMvc.perform(delete("/api/v1/plans/10"))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.errorCode").value(PlanErrorCase.PLAN_ACCESS_DENIED.getErrorCode()));
+    }
 }

--- a/src/test/java/com/bready/server/plan/service/PlanServiceTest.java
+++ b/src/test/java/com/bready/server/plan/service/PlanServiceTest.java
@@ -1,0 +1,234 @@
+package com.bready.server.plan.service;
+
+import com.bready.server.global.exception.ApplicationException;
+import com.bready.server.plan.domain.Plan;
+import com.bready.server.plan.dto.*;
+import com.bready.server.plan.exception.PlanErrorCase;
+import com.bready.server.plan.repository.CategoryStateRepository;
+import com.bready.server.plan.repository.PlanCategoryRepository;
+import com.bready.server.plan.repository.PlanRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class PlanServiceTest {
+
+    @Mock
+    private PlanRepository planRepository;
+
+    @Mock
+    private PlanCategoryRepository planCategoryRepository;
+
+    @Mock
+    private CategoryStateRepository categoryStateRepository;
+
+    @InjectMocks
+    private PlanService planService;
+
+    private final Long USER_ID = 1L;
+    private final Long OTHER_USER_ID = 2L;
+
+    @Nested
+    @DisplayName("플랜 생성")
+    class CreatePlan {
+
+        @Test
+        @DisplayName("성공")
+        void success() {
+            Plan plan = Plan.create(USER_ID, "제목", LocalDate.now(), "서울");
+
+            given(planRepository.save(any()))
+                    .willReturn(plan);
+
+            PlanCreateRequest request = new PlanCreateRequest("제목", LocalDate.now(), "서울");
+
+            PlanCreateResponse response = planService.createPlan(USER_ID, request);
+
+            assertThat(response.getPlanId()).isEqualTo(plan.getId());
+        }
+    }
+
+    @Nested
+    @DisplayName("플랜 수정")
+    class UpdatePlan {
+
+        @Test
+        @DisplayName("성공")
+        void success() {
+            Plan plan = Plan.create(USER_ID, "old", LocalDate.now(), "서울");
+
+            given(planRepository.findByIdAndDeletedAtIsNull(1L))
+                    .willReturn(Optional.of(plan));
+
+            PlanUpdateRequest request = new PlanUpdateRequest("new", LocalDate.now(), "부산");
+
+            PlanUpdateResponse response = planService.updatePlan(USER_ID, 1L, request);
+
+            assertThat(response.getPlanId()).isEqualTo(plan.getId());
+            assertThat(plan.getTitle()).isEqualTo("new");
+        }
+
+        @Test
+        @DisplayName("플랜 없음 → 404")
+        void notFound() {
+            given(planRepository.findByIdAndDeletedAtIsNull(1L))
+                    .willReturn(Optional.empty());
+
+            assertThatThrownBy(() ->
+                    planService.updatePlan(USER_ID, 1L, new PlanUpdateRequest("t", LocalDate.now(), "서울"))
+            ).isInstanceOf(ApplicationException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(PlanErrorCase.PLAN_NOT_FOUND.getErrorCode());
+        }
+
+        @Test
+        @DisplayName("권한 없음 → 403")
+        void accessDenied() {
+            Plan plan = Plan.create(OTHER_USER_ID, "title", LocalDate.now(), "서울");
+
+            given(planRepository.findByIdAndDeletedAtIsNull(1L))
+                    .willReturn(Optional.of(plan));
+
+            assertThatThrownBy(() ->
+                    planService.updatePlan(USER_ID, 1L, new PlanUpdateRequest("t", LocalDate.now(), "서울"))
+            ).isInstanceOf(ApplicationException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(PlanErrorCase.PLAN_ACCESS_DENIED.getErrorCode());
+        }
+    }
+
+    @Nested
+    @DisplayName("플랜 상세 조회")
+    class GetPlanDetail {
+
+        @Test
+        @DisplayName("플랜 없음 → 404")
+        void notFound() {
+            given(planRepository.findByIdAndDeletedAtIsNull(1L))
+                    .willReturn(Optional.empty());
+
+            assertThatThrownBy(() ->
+                    planService.getPlanDetail(USER_ID, 1L)
+            ).isInstanceOf(ApplicationException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(PlanErrorCase.PLAN_NOT_FOUND.getErrorCode());
+        }
+
+        @Test
+        @DisplayName("권한 없음 → 403")
+        void accessDenied() {
+            Plan plan = Plan.create(OTHER_USER_ID, "title", LocalDate.now(), "서울");
+
+            given(planRepository.findByIdAndDeletedAtIsNull(1L))
+                    .willReturn(Optional.of(plan));
+
+            assertThatThrownBy(() ->
+                    planService.getPlanDetail(USER_ID, 1L)
+            ).isInstanceOf(ApplicationException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(PlanErrorCase.PLAN_ACCESS_DENIED.getErrorCode());
+        }
+
+        @Test
+        @DisplayName("카테고리 없음 → 빈 리스트 반환")
+        void emptyCategories() {
+            Plan plan = Plan.create(USER_ID, "title", LocalDate.now(), "서울");
+
+            given(planRepository.findByIdAndDeletedAtIsNull(1L))
+                    .willReturn(Optional.of(plan));
+
+            given(planCategoryRepository.findAllDetailByPlanId(1L))
+                    .willReturn(List.of());
+
+            PlanDetailResponse response = planService.getPlanDetail(USER_ID, 1L);
+
+            assertThat(response.getCategories()).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("플랜 조회")
+    class GetMyPlans {
+
+        @Test
+        @DisplayName("성공")
+        void success() {
+            Plan plan = Plan.create(USER_ID, "title", LocalDate.now(), "서울");
+
+            Page<Plan> page = new PageImpl<>(List.of(plan));
+
+            given(planRepository.findAllByOwnerIdAndDeletedAtIsNull(eq(USER_ID), any(Pageable.class)))
+                    .willReturn(page);
+
+            PlanListResponse response = planService.getMyPlans(USER_ID, 0, 10, SortDirection.DESC);
+
+            assertThat(response.getItems()).hasSize(1);
+            assertThat(response.getItems().get(0).getPlanId()).isEqualTo(plan.getId());
+        }
+    }
+
+    @Nested
+    @DisplayName("플랜 삭제")
+    class DeletePlan {
+
+        @Test
+        @DisplayName("성공 (soft delete)")
+        void success() {
+            Plan plan = Plan.create(USER_ID, "title", LocalDate.now(), "서울");
+
+            given(planRepository.findByIdAndDeletedAtIsNull(1L))
+                    .willReturn(Optional.of(plan));
+
+            PlanDeleteResponse response = planService.deletePlan(USER_ID, 1L);
+
+            assertThat(response.getPlanId()).isEqualTo(plan.getId());
+            assertThat(plan.getDeletedAt()).isNotNull();
+        }
+
+        @Test
+        @DisplayName("플랜 없음 → 404")
+        void notFound() {
+            given(planRepository.findByIdAndDeletedAtIsNull(1L))
+                    .willReturn(Optional.empty());
+
+            assertThatThrownBy(() ->
+                    planService.deletePlan(USER_ID, 1L)
+            ).isInstanceOf(ApplicationException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(PlanErrorCase.PLAN_NOT_FOUND.getErrorCode());
+        }
+
+        @Test
+        @DisplayName("권한 없음 → 403")
+        void accessDenied() {
+            Plan plan = Plan.create(OTHER_USER_ID, "title", LocalDate.now(), "서울");
+
+            given(planRepository.findByIdAndDeletedAtIsNull(1L))
+                    .willReturn(Optional.of(plan));
+
+            assertThatThrownBy(() ->
+                    planService.deletePlan(USER_ID, 1L)
+            ).isInstanceOf(ApplicationException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(PlanErrorCase.PLAN_ACCESS_DENIED.getErrorCode());
+        }
+    }
+}

--- a/src/test/java/com/bready/server/s3/S3ControllerTest.java
+++ b/src/test/java/com/bready/server/s3/S3ControllerTest.java
@@ -1,0 +1,86 @@
+package com.bready.server.s3;
+
+import com.bready.server.s3.controller.S3Controller;
+import com.bready.server.s3.service.S3Uploader;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(S3Controller.class)
+@AutoConfigureMockMvc(addFilters = false)
+class S3ControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private S3Uploader s3Uploader;
+
+    @Test
+    @DisplayName("파일 업로드 성공 → 200")
+    void upload_success() throws Exception {
+
+        MockMultipartFile file = new MockMultipartFile(
+                "file",
+                "test.jpg",
+                MediaType.IMAGE_JPEG_VALUE,
+                "dummy-image".getBytes()
+        );
+
+        String fileKey = "public/test/uuid.jpg";
+        String url = "https://bucket.s3.amazonaws.com/public/test/uuid.jpg";
+
+        given(s3Uploader.uploadAndReturnKey(any(), eq("test")))
+                .willReturn(fileKey);
+
+        given(s3Uploader.buildUrl(fileKey))
+                .willReturn(url);
+
+        mockMvc.perform(multipart("/api/v1/files/upload")
+                        .file(file)
+                        .contentType(MediaType.MULTIPART_FORM_DATA))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.fileKey").value(fileKey))
+                .andExpect(jsonPath("$.data.url").value(url));
+    }
+
+    @Test
+    @DisplayName("파일 없음 → 400")
+    void upload_fail_no_file() throws Exception {
+        mockMvc.perform(multipart("/api/v1/files/upload"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("S3 업로드 실패 → 500")
+    void upload_fail_s3_error() throws Exception {
+
+        MockMultipartFile file = new MockMultipartFile(
+                "file",
+                "test.jpg",
+                MediaType.IMAGE_JPEG_VALUE,
+                "dummy-image".getBytes()
+        );
+
+        given(s3Uploader.uploadAndReturnKey(any(), eq("test")))
+                .willThrow(new RuntimeException("S3 error"));
+
+        mockMvc.perform(multipart("/api/v1/files/upload")
+                        .file(file))
+                .andExpect(status().isInternalServerError());
+    }
+}
+

--- a/src/test/java/com/bready/server/s3/controller/S3ControllerTest.java
+++ b/src/test/java/com/bready/server/s3/controller/S3ControllerTest.java
@@ -1,6 +1,5 @@
-package com.bready.server.s3;
+package com.bready.server.s3.controller;
 
-import com.bready.server.s3.controller.S3Controller;
 import com.bready.server.s3.service.S3Uploader;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/bready/server/s3/controller/S3ControllerTest.java
+++ b/src/test/java/com/bready/server/s3/controller/S3ControllerTest.java
@@ -1,11 +1,13 @@
 package com.bready.server.s3.controller;
 
+import com.bready.server.global.exception.GlobalExceptionHandler;
 import com.bready.server.s3.service.S3Uploader;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
@@ -19,6 +21,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(S3Controller.class)
+@Import(GlobalExceptionHandler.class)
 @AutoConfigureMockMvc(addFilters = false)
 class S3ControllerTest {
 
@@ -60,7 +63,8 @@ class S3ControllerTest {
     @DisplayName("파일 없음 → 400")
     void upload_fail_no_file() throws Exception {
         mockMvc.perform(multipart("/api/v1/files/upload"))
-                .andExpect(status().isBadRequest());
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").value(14006));
     }
 
     @Test

--- a/src/test/java/com/bready/server/s3/service/S3UploaderTest.java
+++ b/src/test/java/com/bready/server/s3/service/S3UploaderTest.java
@@ -1,0 +1,188 @@
+package com.bready.server.s3.service;
+
+import com.bready.server.global.exception.ApplicationException;
+import com.bready.server.s3.exception.S3ErrorCase;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willThrow;
+
+@ExtendWith(MockitoExtension.class)
+class S3UploaderTest {
+
+    @Mock
+    private S3Client s3Client;
+
+    private final String bucket = "test-bucket";
+    private final String region = "ap-northeast-2";
+    private final String prefix = "public";
+
+    private S3Uploader s3Uploader;
+
+    private MockMultipartFile createFile(String name) {
+        return new MockMultipartFile(
+                "file",
+                name,
+                "image/jpeg",
+                "dummy".getBytes()
+        );
+    }
+
+    @BeforeEach
+    void setUp() {
+        s3Uploader = new S3Uploader(s3Client, bucket, region, prefix);
+    }
+
+    @Nested
+    @DisplayName("업로드 및 키 발급")
+    class Upload {
+
+        @Test
+        @DisplayName("성공")
+        void success() {
+            MockMultipartFile file = createFile("test.jpg");
+
+            String key = s3Uploader.uploadAndReturnKey(file, "test");
+
+            assertThat(key).startsWith("public/test/");
+            assertThat(key).endsWith(".jpg");
+
+            then(s3Client).should().putObject(
+                    any(PutObjectRequest.class),
+                    any(RequestBody.class)
+            );
+        }
+
+        @Test
+        @DisplayName("빈 파일 → 예외")
+        void emptyFile() {
+            MockMultipartFile file = new MockMultipartFile(
+                    "file",
+                    "test.jpg",
+                    "image/jpeg",
+                    new byte[]{}
+            );
+
+            ApplicationException ex = assertThrows(
+                    ApplicationException.class,
+                    () -> s3Uploader.uploadAndReturnKey(file, "test")
+            );
+
+            assertThat(ex.getErrorCase())
+                    .isEqualTo(S3ErrorCase.EMPTY_FILE);
+        }
+
+        @Test
+        @DisplayName("파일명 없음 → 예외")
+        void noFilename() {
+            MockMultipartFile file = new MockMultipartFile(
+                    "file",
+                    null,
+                    "image/jpeg",
+                    "dummy".getBytes()
+            );
+
+            ApplicationException ex = assertThrows(
+                    ApplicationException.class,
+                    () -> s3Uploader.uploadAndReturnKey(file, "test")
+            );
+
+            assertThat(ex.getErrorCase())
+                    .isEqualTo(S3ErrorCase.FILENAME_NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("확장자 없음 → 예외")
+        void noExtension() {
+            MockMultipartFile file = createFile("test");
+
+            ApplicationException ex = assertThrows(
+                    ApplicationException.class,
+                    () -> s3Uploader.uploadAndReturnKey(file, "test")
+            );
+
+            assertThat(ex.getErrorCase())
+                    .isEqualTo(S3ErrorCase.EXTENSION_NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("S3 업로드 실패 → 예외")
+        void s3Fail() {
+            MockMultipartFile file = createFile("test.jpg");
+
+            willThrow(new RuntimeException("fail"))
+                    .given(s3Client)
+                    .putObject(
+                            any(PutObjectRequest.class),
+                            any(RequestBody.class)
+                    );
+
+            ApplicationException ex = assertThrows(
+                    ApplicationException.class,
+                    () -> s3Uploader.uploadAndReturnKey(file, "test")
+            );
+
+            assertThat(ex.getErrorCase())
+                    .isEqualTo(S3ErrorCase.FILE_UPLOAD_FAIL);
+        }
+    }
+
+    @Nested
+    @DisplayName("S3 삭제")
+    class Delete {
+
+        @Test
+        @DisplayName("성공")
+        void success() {
+            s3Uploader.delete("key");
+
+            then(s3Client).should().deleteObject(
+                    any(DeleteObjectRequest.class)
+            );
+        }
+
+        @Test
+        @DisplayName("S3 삭제 실패 → 예외")
+        void fail() {
+            willThrow(new RuntimeException())
+                    .given(s3Client)
+                    .deleteObject(
+                            any(DeleteObjectRequest.class)
+                    );
+
+            ApplicationException ex = assertThrows(
+                    ApplicationException.class,
+                    () -> s3Uploader.delete("key")
+            );
+
+            assertThat(ex.getErrorCase())
+                    .isEqualTo(S3ErrorCase.FILE_DELETE_FAIL);
+        }
+    }
+
+    @Test
+    @DisplayName("URL 생성")
+    void buildUrl() {
+        String key = "public/test/uuid.jpg";
+
+        String url = s3Uploader.buildUrl(key);
+
+        assertThat(url).isEqualTo(
+                "https://test-bucket.s3.ap-northeast-2.amazonaws.com/" + key
+        );
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #97 

## 📝 작업 내용

> 플랜 도메인과 S3 도메인의 컨트롤러,서비스 로직에 대한 테스트코드 작성 

## 🖼️ 스크린샷 (선택)

> UI 변경 등 시각적으로 확인할 수 있는 내용이 있다면 첨부해주세요

## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특히 봐주었으면 하는 부분이 있다면 작성해주세요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 예외 응답에서 에러 코드와 HTTP 상태 코드를 직접 조회할 수 있음
  * 파일 업로드 관련 "파일이 필요합니다" 오류 유형 추가

* **Bug Fixes**
  * 요청 파라미터 누락 및 유효성 실패에 대해 일관된 400 응답 처리 개선
  * 파일 업로드/파트 누락 시 보다 명확한 오류 응답 제공

* **Tests**
  * 플랜, 검색, S3 업로드 등 광범위한 단위·통합 테스트 추가 및 검증 강화
<!-- end of auto-generated comment: release notes by coderabbit.ai -->