### PR TITLE
[test] 인증 도메인 관련 테스트코드 작성 

### DIFF
--- a/src/test/java/com/bready/server/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/bready/server/auth/controller/AuthControllerTest.java
@@ -1,0 +1,141 @@
+package com.bready.server.auth.controller;
+
+import com.bready.server.auth.dto.*;
+import com.bready.server.auth.service.AuthService;
+import com.bready.server.auth.service.KakaoAuthService;
+import com.bready.server.auth.service.NaverAuthService;
+import com.bready.server.global.exception.GlobalExceptionHandler;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.ArgumentMatchers.any;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(AuthController.class)
+@Import(GlobalExceptionHandler.class)
+@AutoConfigureMockMvc(addFilters = false)
+class AuthControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private AuthService authService;
+
+    @MockitoBean
+    private KakaoAuthService kakaoAuthService;
+
+    @MockitoBean
+    private NaverAuthService naverAuthService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    @DisplayName("회원가입 성공")
+    void signup_success() throws Exception {
+
+        String requestJson = """
+            {
+              "email": "test@test.com",
+              "password": "password123!",
+              "nickname": "nickname"
+            }
+        """;
+
+        SignupResponse response = SignupResponse.builder()
+                .userId(1L)
+                .nickname("nickname")
+                .email("test@test.com")
+                .createdAt("2026-03-29")
+                .build();
+
+        given(authService.signup(any())).willReturn(response);
+
+        mockMvc.perform(post("/api/v1/auth/signup")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestJson))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.data.userId").value(1L))
+                .andExpect(jsonPath("$.data.nickname").value("nickname"));
+    }
+
+    @Test
+    @DisplayName("로그인 성공")
+    void login_success() throws Exception {
+
+        String requestJson = """
+            {
+              "email": "test@test.com",
+              "password": "password123!"
+            }
+        """;
+
+        TokenResponse response = TokenResponse.builder()
+                .accessToken("access")
+                .refreshToken("refresh")
+                .build();
+
+        given(authService.login(any())).willReturn(response);
+
+        mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestJson))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.accessToken").value("access"))
+                .andExpect(jsonPath("$.data.refreshToken").value("refresh"));
+    }
+
+    @Test
+    @DisplayName("토큰 재발급 성공")
+    void refresh_success() throws Exception {
+
+        String requestJson = """
+            {
+              "refreshToken": "refresh"
+            }
+        """;
+
+        TokenResponse response = TokenResponse.builder()
+                .accessToken("newAccess")
+                .refreshToken("newRefresh")
+                .build();
+
+        given(authService.refresh(any())).willReturn(response);
+
+        mockMvc.perform(post("/api/v1/auth/refresh")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestJson))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.accessToken").value("newAccess"))
+                .andExpect(jsonPath("$.data.refreshToken").value("newRefresh"));
+    }
+
+    @Test
+    @DisplayName("로그아웃 성공")
+    void logout_success() throws Exception {
+
+        String requestJson = """
+            {
+              "refreshToken": "refresh"
+            }
+        """;
+
+        mockMvc.perform(post("/api/v1/auth/logout")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestJson))
+                .andExpect(status().isOk());
+    }
+}

--- a/src/test/java/com/bready/server/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/bready/server/auth/service/AuthServiceTest.java
@@ -1,0 +1,284 @@
+package com.bready.server.auth.service;
+
+import com.bready.server.auth.domain.RefreshToken;
+import com.bready.server.auth.dto.*;
+import com.bready.server.auth.repository.RefreshTokenRepository;
+import com.bready.server.global.config.security.jwt.JwtTokenProvider;
+import com.bready.server.global.exception.ApplicationException;
+import com.bready.server.user.domain.User;
+import com.bready.server.user.domain.UserProfile;
+import com.bready.server.user.repository.UserProfileRepository;
+import com.bready.server.user.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class AuthServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private UserProfileRepository userProfileRepository;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @Mock
+    private JwtTokenProvider jwtTokenProvider;
+
+    @Mock
+    private RefreshTokenRepository refreshTokenRepository;
+
+    @Mock
+    private TokenIssuer tokenIssuer;
+
+    @InjectMocks
+    private AuthService authService;
+
+    @Mock
+    private User user;
+
+    @Mock
+    private UserProfile profile;
+
+    @Nested
+    class SignupTest {
+
+        @Test
+        @DisplayName("회원가입 성공")
+        void signup_success() {
+            SignupRequest request = mock(SignupRequest.class);
+
+            given(request.getEmail()).willReturn("test@test.com");
+            given(request.getPassword()).willReturn("password");
+            given(request.getNickname()).willReturn("nickname");
+
+            given(userRepository.existsByEmail("test@test.com")).willReturn(false);
+            given(passwordEncoder.encode("password")).willReturn("encoded");
+
+            given(userRepository.save(any())).willReturn(user);
+            given(userProfileRepository.save(any())).willReturn(profile);
+
+            given(user.getId()).willReturn(1L);
+            given(user.getEmail()).willReturn("test@test.com");
+            given(user.getCreatedAt()).willReturn(null);
+            given(profile.getNickname()).willReturn("nickname");
+
+            SignupResponse result = authService.signup(request);
+
+            assertThat(result.getUserId()).isEqualTo(1L);
+            assertThat(result.getNickname()).isEqualTo("nickname");
+        }
+
+        @Test
+        @DisplayName("이메일 중복 예외")
+        void signup_duplicateEmail() {
+            SignupRequest request = mock(SignupRequest.class);
+            given(request.getEmail()).willReturn("test@test.com");
+
+            given(userRepository.existsByEmail("test@test.com")).willReturn(true);
+
+            assertThatThrownBy(() -> authService.signup(request))
+                    .isInstanceOf(ApplicationException.class);
+        }
+
+        @Test
+        @DisplayName("DB unique 예외 발생")
+        void signup_dataIntegrityViolation() {
+
+            SignupRequest request = new SignupRequest();
+            ReflectionTestUtils.setField(request, "email", "test@test.com");
+            ReflectionTestUtils.setField(request, "password", "password");
+            ReflectionTestUtils.setField(request, "nickname", "nickname");
+
+            given(userRepository.existsByEmail(any())).willReturn(false);
+
+            given(userRepository.save(any()))
+                    .willThrow(DataIntegrityViolationException.class);
+
+            assertThatThrownBy(() -> authService.signup(request))
+                    .isInstanceOf(ApplicationException.class);
+        }
+    }
+
+    @Nested
+    class LoginTest {
+
+        @Test
+        @DisplayName("로그인 성공")
+        void login_success() {
+            LoginRequest request = mock(LoginRequest.class);
+
+            given(request.getEmail()).willReturn("test@test.com");
+            given(request.getPassword()).willReturn("password");
+
+            given(userRepository.findByEmail("test@test.com"))
+                    .willReturn(Optional.of(user));
+
+            given(user.getPassword()).willReturn("encoded");
+            given(passwordEncoder.matches("password", "encoded"))
+                    .willReturn(true);
+
+            given(user.getId()).willReturn(1L);
+
+            TokenResponse token = TokenResponse.builder()
+                    .accessToken("access")
+                    .refreshToken("refresh")
+                    .build();
+
+            given(tokenIssuer.issue(1L)).willReturn(token);
+
+            TokenResponse result = authService.login(request);
+
+            assertThat(result.getAccessToken()).isEqualTo("access");
+        }
+
+        @Test
+        @DisplayName("이메일 없음")
+        void login_userNotFound() {
+            LoginRequest request = mock(LoginRequest.class);
+            given(request.getEmail()).willReturn("test@test.com");
+
+            given(userRepository.findByEmail(any()))
+                    .willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> authService.login(request))
+                    .isInstanceOf(ApplicationException.class);
+        }
+
+        @Test
+        @DisplayName("비밀번호 틀림")
+        void login_wrongPassword() {
+            LoginRequest request = mock(LoginRequest.class);
+
+            given(request.getEmail()).willReturn("test@test.com");
+            given(request.getPassword()).willReturn("wrong");
+
+            given(userRepository.findByEmail(any()))
+                    .willReturn(Optional.of(user));
+
+            given(user.getPassword()).willReturn("encoded");
+            given(passwordEncoder.matches(any(), any()))
+                    .willReturn(false);
+
+            assertThatThrownBy(() -> authService.login(request))
+                    .isInstanceOf(ApplicationException.class);
+        }
+    }
+
+    @Nested
+    class RefreshTest {
+
+        @Test
+        @DisplayName("토큰 재발급 성공")
+        void refresh_success() {
+            RefreshRequest request = mock(RefreshRequest.class);
+            given(request.getRefreshToken()).willReturn("refresh");
+
+            given(jwtTokenProvider.getUserId("refresh")).willReturn(1L);
+
+            RefreshToken saved = mock(RefreshToken.class);
+            given(saved.getToken()).willReturn("refresh");
+
+            given(refreshTokenRepository.findById("1"))
+                    .willReturn(Optional.of(saved));
+
+            TokenResponse token = TokenResponse.builder()
+                    .accessToken("newAccess")
+                    .refreshToken("newRefresh")
+                    .build();
+
+            given(tokenIssuer.issue(1L)).willReturn(token);
+
+            TokenResponse result = authService.refresh(request);
+
+            assertThat(result.getAccessToken()).isEqualTo("newAccess");
+        }
+
+        @Test
+        @DisplayName("Redis 토큰 없음")
+        void refresh_notFound() {
+            RefreshRequest request = mock(RefreshRequest.class);
+            given(request.getRefreshToken()).willReturn("refresh");
+
+            given(jwtTokenProvider.getUserId("refresh")).willReturn(1L);
+            given(refreshTokenRepository.findById("1"))
+                    .willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> authService.refresh(request))
+                    .isInstanceOf(ApplicationException.class);
+        }
+
+        @Test
+        @DisplayName("토큰 불일치")
+        void refresh_invalidToken() {
+            RefreshRequest request = mock(RefreshRequest.class);
+            given(request.getRefreshToken()).willReturn("refresh");
+
+            given(jwtTokenProvider.getUserId("refresh")).willReturn(1L);
+
+            RefreshToken saved = mock(RefreshToken.class);
+            given(saved.getToken()).willReturn("different");
+
+            given(refreshTokenRepository.findById("1"))
+                    .willReturn(Optional.of(saved));
+
+            assertThatThrownBy(() -> authService.refresh(request))
+                    .isInstanceOf(ApplicationException.class);
+        }
+    }
+
+    @Nested
+    class LogoutTest {
+
+        @Test
+        @DisplayName("로그아웃 성공")
+        void logout_success() {
+            RefreshRequest request = mock(RefreshRequest.class);
+            given(request.getRefreshToken()).willReturn("refresh");
+
+            given(jwtTokenProvider.getUserId("refresh")).willReturn(1L);
+
+            RefreshToken saved = mock(RefreshToken.class);
+            given(saved.getToken()).willReturn("refresh");
+
+            given(refreshTokenRepository.findById("1"))
+                    .willReturn(Optional.of(saved));
+
+            authService.logout(request);
+
+            then(refreshTokenRepository).should().deleteById("1");
+        }
+
+        @Test
+        @DisplayName("토큰 불일치")
+        void logout_invalidToken() {
+            RefreshRequest request = mock(RefreshRequest.class);
+            given(request.getRefreshToken()).willReturn("refresh");
+
+            given(jwtTokenProvider.getUserId("refresh")).willReturn(1L);
+
+            RefreshToken saved = mock(RefreshToken.class);
+            given(saved.getToken()).willReturn("different");
+
+            given(refreshTokenRepository.findById("1"))
+                    .willReturn(Optional.of(saved));
+
+            assertThatThrownBy(() -> authService.logout(request))
+                    .isInstanceOf(ApplicationException.class);
+        }
+    }
+}

--- a/src/test/java/com/bready/server/user/controller/UserControllerTest.java
+++ b/src/test/java/com/bready/server/user/controller/UserControllerTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.core.MethodParameter;
 import org.springframework.http.MediaType;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
@@ -36,6 +37,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @ExtendWith(MockitoExtension.class)
+@AutoConfigureMockMvc(addFilters = false)
 class UserControllerTest {
 
     @Mock


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #97 

## 📝 작업 내용

> 인증 도메인 컨트롤러,서비스 로직에 대한 테스트코드를 작성했습니다.

## 🖼️ 스크린샷 (선택)

> 모든 테스트 통과 확인 완료 

## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특히 봐주었으면 하는 부분이 있다면 작성해주세요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Tests
- 인증 엔드포인트(회원가입, 로그인, 토큰 갱신, 로그아웃)에 대한 포괄적인 테스트 커버리지 추가
- 성공 및 실패 시나리오를 포함한 인증 서비스 계층 테스트 추가
- 사용자 관리 엔드포인트에 대한 테스트 구성 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->