### PR TITLE
[feat] 플랜 공유 API 구현 및 공개 조회 기능 추가

### DIFF
--- a/src/main/java/com/bready/server/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/bready/server/global/config/security/SecurityConfig.java
@@ -57,6 +57,7 @@ public class SecurityConfig {
                         ).permitAll()
                         .requestMatchers("/actuator/health", "/actuator/info").permitAll()
                         .requestMatchers("/api/v1/auth/**").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/v1/plans/shared/**").permitAll()
                         .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                         .anyRequest().authenticated()
                 )

--- a/src/main/java/com/bready/server/plan/controller/PlanController.java
+++ b/src/main/java/com/bready/server/plan/controller/PlanController.java
@@ -13,6 +13,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 @RestController
 @RequestMapping("/api/v1/plans")
@@ -99,6 +100,36 @@ public class PlanController {
         return CommonResponse.success(planService.getPlanDetail(userId, planId));
     }
 
+    @PostMapping("/{planId}/share")
+    @ResponseStatus(HttpStatus.OK)
+    @Operation(
+            summary = "플랜 공유 링크 생성",
+            description = "플랜 소유자가 공유 링크를 생성하거나 기존 링크를 조회합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "공유 링크 생성 성공",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "401", description = "인증 필요",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "403", description = "플랜 공유 권한 없음",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "404", description = "플랜 없음",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class)))
+    })
+    public CommonResponse<String> createShareLink(
+            @CurrentUser Long userId,
+            @PathVariable Long planId
+    ) {
+        String shareToken = planService.getOrCreateShareToken(userId, planId);
+
+        String shareUrl = ServletUriComponentsBuilder.fromCurrentContextPath()
+                .path("/shared/plans/")
+                .path(shareToken)
+                .toUriString();
+
+        return CommonResponse.success(shareUrl);
+    }
+
 
     @GetMapping
     @ResponseStatus(HttpStatus.OK)
@@ -144,6 +175,24 @@ public class PlanController {
     })
     public CommonResponse<PlanDeleteResponse> deletePlan(@CurrentUser Long userId, @PathVariable Long planId) {
         return CommonResponse.success(planService.deletePlan(userId, planId));
+    }
+
+    @GetMapping("/shared/{shareToken}")
+    @ResponseStatus(HttpStatus.OK)
+    @Operation(
+            summary = "공유 플랜 상세 조회",
+            description = "공유 토큰으로 플랜 상세 정보를 조회합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "공유 플랜 조회 성공",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "404", description = "공유 플랜 없음",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class)))
+    })
+    public CommonResponse<PlanDetailResponse> getSharedPlanDetail(
+            @PathVariable String shareToken
+    ) {
+        return CommonResponse.success(planService.getSharedPlanDetail(shareToken));
     }
 
 }

--- a/src/main/java/com/bready/server/plan/controller/PlanController.java
+++ b/src/main/java/com/bready/server/plan/controller/PlanController.java
@@ -10,13 +10,16 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Pattern;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/v1/plans")
 @RequiredArgsConstructor
+@Validated
 public class PlanController {
 
     private final PlanService planService;
@@ -183,7 +186,9 @@ public class PlanController {
                     content = @Content(schema = @Schema(implementation = CommonResponse.class)))
     })
     public CommonResponse<PlanDetailResponse> getSharedPlanDetail(
-            @PathVariable String shareToken
+            @PathVariable
+            @Pattern(regexp = "^[a-f0-9]{32}$", message = "invalid shareToken")
+            String shareToken
     ) {
         return CommonResponse.success(planService.getSharedPlanDetail(shareToken));
     }

--- a/src/main/java/com/bready/server/plan/controller/PlanController.java
+++ b/src/main/java/com/bready/server/plan/controller/PlanController.java
@@ -13,7 +13,6 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 @RestController
 @RequestMapping("/api/v1/plans")
@@ -121,13 +120,7 @@ public class PlanController {
             @PathVariable Long planId
     ) {
         String shareToken = planService.getOrCreateShareToken(userId, planId);
-
-        String shareUrl = ServletUriComponentsBuilder.fromCurrentContextPath()
-                .path("/shared/plans/")
-                .path(shareToken)
-                .toUriString();
-
-        return CommonResponse.success(shareUrl);
+        return CommonResponse.success(shareToken);
     }
 
 

--- a/src/main/java/com/bready/server/plan/domain/Plan.java
+++ b/src/main/java/com/bready/server/plan/domain/Plan.java
@@ -32,6 +32,9 @@ public class Plan extends BaseEntity {
     @Column(nullable = false)
     private String status;
 
+    @Column(name = "share_token", unique = true)
+    private String shareToken;
+
     public static Plan create(Long ownerId, String title, LocalDate planDate, String region) {
         Plan plan = new Plan();
         plan.ownerId = ownerId;
@@ -39,6 +42,7 @@ public class Plan extends BaseEntity {
         plan.planDate = planDate;
         plan.region = region;
         plan.status = "ACTIVE";
+        plan.shareToken = null;
         return plan;
     }
 

--- a/src/main/java/com/bready/server/plan/domain/Plan.java
+++ b/src/main/java/com/bready/server/plan/domain/Plan.java
@@ -51,4 +51,8 @@ public class Plan extends BaseEntity {
         this.planDate = planDate;
         this.region = region;
     }
+
+    public void setShareToken(String shareToken) {
+        this.shareToken = shareToken;
+    }
 }

--- a/src/main/java/com/bready/server/plan/dto/PlanDto.java
+++ b/src/main/java/com/bready/server/plan/dto/PlanDto.java
@@ -15,6 +15,8 @@ public class PlanDto {
     private LocalDate planDate;
     private String region;
     private String status;
+    private String ownerNickname;
+    private String ownerProfileImageUrl;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 

--- a/src/main/java/com/bready/server/plan/repository/PlanRepository.java
+++ b/src/main/java/com/bready/server/plan/repository/PlanRepository.java
@@ -48,6 +48,8 @@ public interface PlanRepository extends JpaRepository<Plan, Long> {
     // 조회용 - 락 없음
     Optional<Plan> findByIdAndDeletedAtIsNull(Long id);
 
+    Optional<Plan> findByShareTokenAndDeletedAtIsNull(String shareToken);
+
     @Query(value = """
     SELECT
         p.id as planId,

--- a/src/main/java/com/bready/server/plan/service/PlanService.java
+++ b/src/main/java/com/bready/server/plan/service/PlanService.java
@@ -231,7 +231,7 @@ public class PlanService {
 
     @Transactional
     public String getOrCreateShareToken(Long userId, Long planId) {
-        Plan plan = planRepository.findByIdAndDeletedAtIsNull(planId)
+        Plan plan = planRepository.findByIdAndDeletedAtIsNullForUpdate(planId)
                 .orElseThrow(() -> new ApplicationException(PlanErrorCase.PLAN_NOT_FOUND));
 
         if (!plan.getOwnerId().equals(userId)) {

--- a/src/main/java/com/bready/server/plan/service/PlanService.java
+++ b/src/main/java/com/bready/server/plan/service/PlanService.java
@@ -74,17 +74,21 @@ public class PlanService {
             throw new ApplicationException(PlanErrorCase.PLAN_ACCESS_DENIED);
         }
 
-        PlanDto planDto = PlanDto.builder()
-                .planId(plan.getId())
-                .title(plan.getTitle())
-                .planDate(plan.getPlanDate())
-                .region(plan.getRegion())
-                .status(plan.getStatus())
-                .createdAt(plan.getCreatedAt())
-                .updatedAt(plan.getUpdatedAt())
-                .build();
+        return buildPlanDetailResponse(plan);
+    }
 
-        List<PlanCategory> categories = planCategoryRepository.findAllDetailByPlanId(planId);
+    @Transactional(readOnly = true)
+    public PlanDetailResponse getSharedPlanDetail(String shareToken) {
+        Plan plan = planRepository.findByShareTokenAndDeletedAtIsNull(shareToken)
+                .orElseThrow(() -> new ApplicationException(PlanErrorCase.PLAN_NOT_FOUND));
+
+        return buildPlanDetailResponse(plan);
+    }
+
+    private PlanDetailResponse buildPlanDetailResponse(Plan plan) {
+        PlanDto planDto = buildPlanDto(plan);
+
+        List<PlanCategory> categories = planCategoryRepository.findAllDetailByPlanId(plan.getId());
 
         if (categories.isEmpty()) {
             return PlanDetailResponse.builder()
@@ -97,53 +101,68 @@ public class PlanService {
                 .map(PlanCategory::getId)
                 .toList();
 
-        Map<Long, Long> representativeMap =
-                categoryStateRepository.findAllByCategory_IdIn(categoryIds)
-                        .stream()
-                        .filter(cs -> cs.getCurrentCandidateId() != null)
-                        .collect(Collectors.toMap(
-                                cs -> cs.getCategory().getId(),
-                                CategoryState::getCurrentCandidateId
-                        ));
+        Map<Long, Long> representativeMap = categoryStateRepository.findAllByCategory_IdIn(categoryIds)
+                .stream()
+                .filter(cs -> cs.getCurrentCandidateId() != null)
+                .collect(Collectors.toMap(
+                        cs -> cs.getCategory().getId(),
+                        CategoryState::getCurrentCandidateId
+                ));
 
         List<PlanDetailCategoryDto> categoryDtos = categories.stream()
-                .map(category-> {
-                    Long representativeId = representativeMap.get(category.getId());
-
-                    List<PlanDetailCandidateDto> candidateDtos =
-                            category.getCandidates().stream()
-                                    .sorted((a,b) -> Long.compare(b.getId(), a.getId()))
-                                    .map(candidate -> {
-                                        boolean isRep = representativeId != null && representativeId.equals(candidate.getId());
-
-                                        return PlanDetailCandidateDto.builder()
-                                                .candidateId(candidate.getId())
-                                                .isRepresentative(isRep)
-                                                .place(PlanDetailPlaceDto.builder()
-                                                        .id(candidate.getPlace().getId())
-                                                        .externalId(candidate.getPlace().getExternalId())
-                                                        .name(candidate.getPlace().getName())
-                                                        .address(candidate.getPlace().getAddress())
-                                                        .latitude(candidate.getPlace().getLatitude())
-                                                        .longitude(candidate.getPlace().getLongitude())
-                                                        .isIndoor(candidate.getPlace().getIsIndoor())
-                                                        .build())
-                                                .build();
-                                    }).toList();
-                    return PlanDetailCategoryDto.builder()
-                            .planCategoryId(category.getId())
-                            .categoryType(category.getCategoryType())
-                            .sequence(category.getSequence())
-                            .representativeCandidateId(representativeId)
-                            .candidates(candidateDtos)
-                            .build();
-                }).toList();
+                .map(category -> buildCategoryDto(category, representativeMap.get(category.getId())))
+                .toList();
 
         return PlanDetailResponse.builder()
                 .plan(planDto)
                 .categories(categoryDtos)
                 .build();
     }
+
+
+    private PlanDto buildPlanDto(Plan plan) {
+        return PlanDto.builder()
+                .planId(plan.getId())
+                .title(plan.getTitle())
+                .planDate(plan.getPlanDate())
+                .region(plan.getRegion())
+                .status(plan.getStatus())
+                .createdAt(plan.getCreatedAt())
+                .updatedAt(plan.getUpdatedAt())
+                .build();
+    }
+
+    private PlanDetailCategoryDto buildCategoryDto(PlanCategory category, Long representativeId) {
+        List<PlanDetailCandidateDto> candidateDtos = category.getCandidates().stream()
+                .sorted((a, b) -> Long.compare(b.getId(), a.getId()))
+                .map(candidate -> {
+                    boolean isRep = representativeId != null && representativeId.equals(candidate.getId());
+
+                    return PlanDetailCandidateDto.builder()
+                            .candidateId(candidate.getId())
+                            .isRepresentative(isRep)
+                            .place(PlanDetailPlaceDto.builder()
+                                    .id(candidate.getPlace().getId())
+                                    .externalId(candidate.getPlace().getExternalId())
+                                    .name(candidate.getPlace().getName())
+                                    .address(candidate.getPlace().getAddress())
+                                    .latitude(candidate.getPlace().getLatitude())
+                                    .longitude(candidate.getPlace().getLongitude())
+                                    .isIndoor(candidate.getPlace().getIsIndoor())
+                                    .build())
+                            .build();
+                })
+                .toList();
+
+        return PlanDetailCategoryDto.builder()
+                .planCategoryId(category.getId())
+                .categoryType(category.getCategoryType())
+                .sequence(category.getSequence())
+                .representativeCandidateId(representativeId)
+                .candidates(candidateDtos)
+                .build();
+    }
+
 
     @Transactional(readOnly = true)
     public PlanListResponse getMyPlans(Long userId, int page, int size, SortDirection order) {

--- a/src/main/java/com/bready/server/plan/service/PlanService.java
+++ b/src/main/java/com/bready/server/plan/service/PlanService.java
@@ -9,6 +9,9 @@ import com.bready.server.plan.exception.PlanErrorCase;
 import com.bready.server.plan.repository.CategoryStateRepository;
 import com.bready.server.plan.repository.PlanCategoryRepository;
 import com.bready.server.plan.repository.PlanRepository;
+import com.bready.server.user.domain.User;
+import com.bready.server.user.domain.UserProfile;
+import com.bready.server.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -29,6 +32,7 @@ public class PlanService {
     private final PlanRepository planRepository;
     private final PlanCategoryRepository planCategoryRepository;
     private final CategoryStateRepository categoryStateRepository;
+    private final UserRepository userRepository;
 
     @Transactional
     public PlanCreateResponse createPlan(Long userId, PlanCreateRequest request) {
@@ -121,12 +125,22 @@ public class PlanService {
 
 
     private PlanDto buildPlanDto(Plan plan) {
+        User user = userRepository.findByIdWithProfile(plan.getOwnerId())
+                .orElseThrow(() -> new ApplicationException(PlanErrorCase.PLAN_NOT_FOUND));
+
+        UserProfile profile = user.getUserProfile();
+
+        String ownerNickname = profile != null ? profile.getNickname() : "사용자";
+        String ownerProfileImageUrl = profile != null ? profile.getProfileImageUrl() : null;
+
         return PlanDto.builder()
                 .planId(plan.getId())
                 .title(plan.getTitle())
                 .planDate(plan.getPlanDate())
                 .region(plan.getRegion())
                 .status(plan.getStatus())
+                .ownerNickname(ownerNickname)
+                .ownerProfileImageUrl(ownerProfileImageUrl)
                 .createdAt(plan.getCreatedAt())
                 .updatedAt(plan.getUpdatedAt())
                 .build();

--- a/src/main/java/com/bready/server/plan/service/PlanService.java
+++ b/src/main/java/com/bready/server/plan/service/PlanService.java
@@ -19,6 +19,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 @Service
@@ -193,5 +194,24 @@ public class PlanService {
                 .planId(plan.getId())
                 .deletedAt(plan.getDeletedAt())
                 .build();
+    }
+
+    @Transactional
+    public String getOrCreateShareToken(Long userId, Long planId) {
+        Plan plan = planRepository.findByIdAndDeletedAtIsNull(planId)
+                .orElseThrow(() -> new ApplicationException(PlanErrorCase.PLAN_NOT_FOUND));
+
+        if (!plan.getOwnerId().equals(userId)) {
+            throw new ApplicationException(PlanErrorCase.PLAN_ACCESS_DENIED);
+        }
+
+        if (plan.getShareToken() != null) {
+            return plan.getShareToken();
+        }
+
+        String token = UUID.randomUUID().toString().replace("-", "");
+        plan.setShareToken(token);
+
+        return token;
     }
 }

--- a/src/main/java/com/bready/server/user/repository/UserRepository.java
+++ b/src/main/java/com/bready/server/user/repository/UserRepository.java
@@ -21,7 +21,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     @Query("""
         select u from User u
-        join fetch u.userProfile
+        left join fetch u.userProfile
         where u.id = :userId
     """)
     Optional<User> findByIdWithProfile(@Param("userId") Long userId);

--- a/src/test/java/com/bready/server/plan/service/PlanServiceTest.java
+++ b/src/test/java/com/bready/server/plan/service/PlanServiceTest.java
@@ -20,6 +20,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -109,6 +110,7 @@ class PlanServiceTest {
         @DisplayName("권한 없음 → 403")
         void accessDenied() {
             Plan plan = Plan.create(OTHER_USER_ID, "title", LocalDate.now(), "서울");
+            ReflectionTestUtils.setField(plan, "id", 1L);
 
             given(planRepository.findByIdAndDeletedAtIsNull(1L))
                     .willReturn(Optional.of(plan));
@@ -157,6 +159,7 @@ class PlanServiceTest {
         @DisplayName("카테고리 없음 → 빈 리스트 반환")
         void emptyCategories() {
             Plan plan = Plan.create(USER_ID, "title", LocalDate.now(), "서울");
+            ReflectionTestUtils.setField(plan, "id", 1L);
 
             User user = User.createLocal("test@test.com", "encoded-password");
 

--- a/src/test/java/com/bready/server/plan/service/PlanServiceTest.java
+++ b/src/test/java/com/bready/server/plan/service/PlanServiceTest.java
@@ -7,6 +7,9 @@ import com.bready.server.plan.exception.PlanErrorCase;
 import com.bready.server.plan.repository.CategoryStateRepository;
 import com.bready.server.plan.repository.PlanCategoryRepository;
 import com.bready.server.plan.repository.PlanRepository;
+import com.bready.server.user.domain.User;
+import com.bready.server.user.domain.UserProfile;
+import com.bready.server.user.repository.UserRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -39,6 +42,9 @@ class PlanServiceTest {
 
     @Mock
     private CategoryStateRepository categoryStateRepository;
+
+    @Mock
+    private UserRepository userRepository;
 
     @InjectMocks
     private PlanService planService;
@@ -151,6 +157,15 @@ class PlanServiceTest {
         @DisplayName("카테고리 없음 → 빈 리스트 반환")
         void emptyCategories() {
             Plan plan = Plan.create(USER_ID, "title", LocalDate.now(), "서울");
+
+            User user = User.createLocal("test@test.com", "encoded-password");
+
+            UserProfile profile = UserProfile.create(user, "테스터");
+
+            profile.changeProfileImage(null);
+
+            given(userRepository.findByIdWithProfile(USER_ID))
+                    .willReturn(Optional.of(user));
 
             given(planRepository.findByIdAndDeletedAtIsNull(1L))
                     .willReturn(Optional.of(plan));


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#108 

## 📝 작업 내용

- 플랜 공유 기능 API 구현
  - 공유 링크 생성을 위한 토큰 발급 로직 추가
  - 플랜 엔티티에 공유 토큰 필드 추가
- 공유 플랜 조회 API 구현
  - 토큰 기반으로 플랜 조회하도록 처리
  - 로그인 없이 접근 가능하도록 보안 설정 수정
- 공유 응답 구조 개선
  - 기존 URL 반환 방식 제거 → 토큰만 반환하도록 변경
  - 프론트에서 URL을 조립하도록 구조 개선
- 작성자 정보 포함
  - 공유 플랜 조회 시 작성자 닉네임 및 프로필 이미지 응답에 포함

## 🖼️ 스크린샷 (선택)
### 관리 버튼 선택
<img width="1065" height="315" alt="573501347-b9080193-3574-4bcf-98b3-8b96c5ff9dde" src="https://github.com/user-attachments/assets/a580186e-0798-4aa7-bf0e-17f72dd13c71" />

- 아이콘 수정됨

### 공유 URL 복사
<img width="1008" height="469" alt="573501379-aadc36b0-290c-470a-bd6d-c23e2fb4499f" src="https://github.com/user-attachments/assets/cc69657e-38ed-440f-a157-c4a9d4ef4b7a" />

### 공유된 플랜
<img width="1223" height="1202" alt="573500797-0de49b51-78db-4e02-9674-34ab688561d1" src="https://github.com/user-attachments/assets/415c7bd8-ff28-4b63-b0bd-2dc1b1713aee" />

> UI 변경 등 시각적으로 확인할 수 있는 내용이 있다면 첨부해주세요

## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특히 봐주었으면 하는 부분이 있다면 작성해주세요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 계획 공유 링크 생성 및 공유 기능 추가(공유 링크로 상세 조회 가능).
  * 공유된 계획은 로그인 없이 접근 가능.
  * 계획 상세에 소유자 닉네임과 프로필 이미지 노출(없을 경우 기본 닉네임 적용).
* **유효성 및 접근제어**
  * 공유 조회 시 입력 유효성 검사 강화 및 공유 URL에 대한 공개 접근 허용 규칙 추가.
* **테스트**
  * 공유 및 조회 관련 테스트 보강.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->